### PR TITLE
Fix: Fix docker tags

### DIFF
--- a/.github/workflows/publish_gradle_docker.yml
+++ b/.github/workflows/publish_gradle_docker.yml
@@ -23,12 +23,12 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.1.0
+      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.3.0
 
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.3.0
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks }}
         run: |
@@ -42,13 +42,13 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.3.0
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0
 
   release:
     needs:
@@ -64,8 +64,8 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.1.0
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.3.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.3.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
            lfs: true
@@ -74,7 +74,7 @@ jobs:
         run: |
            sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
            ./gradlew build -x test
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -86,9 +86,7 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
-            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
-            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_gradle_docker.yml
+++ b/.github/workflows/publish_gradle_docker.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
+      is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
     permissions:
       contents: write
       packages: write
@@ -86,6 +87,10 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
+            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}
+            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}

--- a/.github/workflows/publish_python_docker.yml
+++ b/.github/workflows/publish_python_docker.yml
@@ -23,7 +23,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -36,7 +36,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -55,7 +55,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.3.0
         id: semantic_versioning
 
   release:
@@ -72,7 +72,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.3.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
@@ -81,8 +81,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
-        if: github.ref == 'refs/heads/development'
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -94,9 +93,7 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
-            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
-            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
@@ -106,7 +103,7 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -114,6 +111,6 @@ jobs:
         shell: bash
         run: |
           poetry install --all-extras
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0
         with:
           bypass_checks: ${{ inputs.bypass_ort }}

--- a/.github/workflows/publish_python_docker.yml
+++ b/.github/workflows/publish_python_docker.yml
@@ -51,6 +51,7 @@ jobs:
     outputs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
+      is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
     permissions:
       contents: write
       packages: write
@@ -93,6 +94,10 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
+            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}
+            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -72,7 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
-      current_version: ${{ steps.semantic_versioning.outputs.current_version }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -31,7 +31,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -47,7 +47,7 @@ jobs:
       matrix:
         python-version: [ "3.11", "3.10", "3.9", "3.8" ]
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: "${{ matrix.python-version }}"
           install_poetry: true
@@ -60,13 +60,13 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
       - name: Install dependencies
         shell: bash
         run: |
           pip install poetry
           poetry install
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0
 
   calculate_version:
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.3.0
         id: semantic_versioning
 
   release:
@@ -94,12 +94,12 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.3.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
           token: ${{ secrets.DEPLOY_USER_PAT }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -123,7 +123,7 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run:
           make publish
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_vanilla_docker.yml
+++ b/.github/workflows/publish_vanilla_docker.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
+      is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
     permissions:
       contents: write
       packages: write
@@ -56,6 +57,10 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
+            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}
+            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}

--- a/.github/workflows/publish_vanilla_docker.yml
+++ b/.github/workflows/publish_vanilla_docker.yml
@@ -20,13 +20,13 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.3.0
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0
 
   release:
     needs:
@@ -40,11 +40,11 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.3.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -56,9 +56,7 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
-            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
-            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_yarn_docker.yml
+++ b/.github/workflows/publish_yarn_docker.yml
@@ -19,7 +19,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.3.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -32,7 +32,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.3.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -50,18 +50,18 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.3.0
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
       - name: Install dependencies
         shell: bash
         run: |
           npm i
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0
 
   release:
     needs:
@@ -77,11 +77,11 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.3.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.3.0
         with:
           node_version: ${{ inputs.node_version }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -105,9 +105,7 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
-            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
-            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_yarn_docker.yml
+++ b/.github/workflows/publish_yarn_docker.yml
@@ -46,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
+      is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
     permissions:
       contents: write
       packages: write
@@ -105,6 +106,10 @@ jobs:
           scan: true
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
+            ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}
+            ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
+            ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: epam/ai-dial-ci/actions/publish_tag_release@0.3.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}

--- a/.github/workflows/test_gradle_docker.yml
+++ b/.github/workflows/test_gradle_docker.yml
@@ -27,12 +27,12 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.1.0
+      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.3.0
 
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.3.0
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks }}
         run: |
@@ -41,10 +41,10 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.3.0
       - name: Build
         run: ./gradlew build -x test
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -54,4 +54,4 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0

--- a/.github/workflows/test_python_docker.yml
+++ b/.github/workflows/test_python_docker.yml
@@ -27,7 +27,7 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -40,7 +40,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -66,7 +66,7 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -74,6 +74,6 @@ jobs:
         shell: bash
         run: |
           poetry install --all-extras
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0
         with:
           bypass_checks: ${{ inputs.bypass_ort }}

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -38,7 +38,7 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -54,7 +54,7 @@ jobs:
       matrix:
           python-version: ["3.11", "3.10", "3.9", "3.8"]
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: "${{ matrix.python-version }}"
           install_poetry: true
@@ -67,7 +67,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -91,10 +91,10 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
       - name: Install dependencies
         shell: bash
         run: |
           pip install poetry
           make build
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0

--- a/.github/workflows/test_vanilla_docker.yml
+++ b/.github/workflows/test_vanilla_docker.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -36,4 +36,4 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0

--- a/.github/workflows/test_yarn_docker.yml
+++ b/.github/workflows/test_yarn_docker.yml
@@ -24,7 +24,7 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.3.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -37,7 +37,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.3.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.3.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -63,9 +63,9 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.1.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.3.0
       - name: Install dependencies
         shell: bash
         run: |
           npm i
-      - uses: epam/ai-dial-ci/actions/ort@0.1.0
+      - uses: epam/ai-dial-ci/actions/ort@0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,67 @@
-Coming soon
+# Contributing Guidelines
+
+Thank you for your interest in contributing to our project. The following is a set of guidelines for contributing to this project.
+
+## Workflow
+
+### 1. Installing pre-commit
+
+We use pre-commit to ensure code quality. Please install it following the steps below:
+
+Install pre-commit package globally:
+
+```bash
+pip install pre-commit
+```
+
+Then install the git hook scripts, run:
+
+```bash
+pre-commit install
+```
+
+Pre-commit will now run on every commit. If you want to run pre-commit manually, you can use:
+
+```bash
+pre-commit run
+```
+
+### 2. Creating a Feature Branch
+
+Before you start working, please create a new feature branch. This will ensure your ongoing work does not affect the main branch and makes it easier to merge your changes later.
+
+To create a new branch:
+
+```bash
+git checkout -b your-new-branch
+```
+
+**While doing changes, make sure to update self-dependencies in actions versions.**
+
+### 3. Creating a Pull Request (PR)
+
+Once ready, you can create a PR. Make sure to prefix the title with one of the following: "fix: ", "feat: ", "feature: ", "chore: ", "hotfix: "
+
+This helps maintainers to categorize the PR and understand its purpose easier.
+
+### For Maintainers
+
+After a PR is created, it needs to be checked and reviewed before merging.
+
+#### 1. Checking, Approving, and Merging with squash
+
+Review the changes in the PR and ensure they adhere to the code quality standards and are aligned with the project's objectives. Once approved, merge the PR and squash the commits.
+
+#### 2. Creating a new release
+
+Follow the steps below to create a new release on GitHub:
+
+1. Navigate to your repository homepage.
+1. Click on the "Releases" tab which is next to the "About" section on the right side of the page.
+1. Click on "Draft a new release" button which is toward the right side of the screen.
+1. Select the main branch as the target for the release.
+1. Enter a unique tag for the new version following your project's versioning system. This tag will be used to identify this specific release.
+1. Under "Release title", give a short, meaningful name for the release.
+1. Make sure "Generate Release Notes" option is selected.
+*GitHub will automatically include a changelog of all commit messages since your last release.*
+1. Once all the details are finalized, click on the "Publish release" button.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@0.1.0
+    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@0.3.0
     secrets: inherit
     with:
       bypass_checks: false

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ jobs:
       python_version: 3.8
 ```
 
-
 ## Developer environment
 
 This project contains reusable workflows under [`.github/workflows`](.github/workflows) directory, and composite actions under [`actions`](actions) directory.

--- a/actions/gradle_checkstyle/action.yml
+++ b/actions/gradle_checkstyle/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: epam/ai-dial-ci/actions/prepare_java@0.1.0
+    - uses: epam/ai-dial-ci/actions/prepare_java@0.3.0
       with:
         java_version: ${{ inputs.java_version }}
         java_distribution: ${{ inputs.java_distribution }}

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -11,6 +11,9 @@ outputs:
   non_semver_next_version:
     description: 'Next version without semantic versioning'
     value: ${{ steps.semantic.outputs.non_semver_next_version }}
+  is_latest:
+    description: 'Is a version semantically latest compared to the latest git tag?'
+    value: ${{ steps.semantic.outputs.is_latest }}
 
 runs:
   using: "composite"
@@ -24,11 +27,15 @@ runs:
       id: semantic
       shell: bash
       run: |
+        #!/bin/bash
         #set -x
+
+        function version { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
+
         function bump_version {
           # Split the version string into Major, Minor and Patch numbers
           local VERSION
-          IFS='.' read -r -a VERSION <<< $(echo ${1})
+          IFS='.' read -r -a VERSION <<<"${1}"
           local BRANCH_NAME="$2"
           local MAJOR=${VERSION[0]}
           local MINOR=${VERSION[1]}
@@ -55,7 +62,7 @@ runs:
 
         TAGS=$(git tag)
 
-        if [[ -z "${TAGS// }" ]]; then
+        if [[ -z "${TAGS// /}" ]]; then
           # No tags found
           if [[ "$CURRENT_BRANCH" == "development" ]]; then
             # For development branch with no tags, set the next version to 0.1.0-rc
@@ -70,8 +77,8 @@ runs:
             NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" "${CURRENT_BRANCH}")
           elif [[ "${CURRENT_BRANCH}" =~ "release-" ]]; then
             # For release branch with tags, bump patch version, e.g. v2.3.4 -> v2.3.5
-            CURRENT_VERSION=$(git tag | { grep "^${CURRENT_BRANCH##release-}." || echo '' ;} | sort -V | tail -1)
-            if [[ ! -z "${CURRENT_VERSION// }" ]]; then
+            CURRENT_VERSION=$(git tag | { grep "^${CURRENT_BRANCH##release-}." || echo ''; } | sort -V | tail -1)
+            if [[ -n "${CURRENT_VERSION// /}" ]]; then
               NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" "${CURRENT_BRANCH}")
             else
               # If no tags match the release branch, set the next version to release number with 0 patch version, e.g. v-0.1.0
@@ -82,9 +89,19 @@ runs:
           fi
         fi
 
-        # python packages do not support semantic versioning
-        NON_SEMVER_NEXT_VERSION="$(echo "${NEXT_VERSION}" | sed 's/-//')"
+        # Check if the next version is greater than the latest tag in the repo
+        # Always false if NEXT_VERSION contains '-rc'
+        LATEST_TAG=$(git tag | sort -V | tail -1)
+        if [ "$(version "${NEXT_VERSION//*-/-}")" -gt "$(version "$LATEST_TAG")" ]; then
+          IS_LATEST="true"
+        else
+          IS_LATEST="false"
+        fi
 
-        echo "current_version=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
-        echo "next_version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
-        echo "non_semver_next_version=${NON_SEMVER_NEXT_VERSION}" >> $GITHUB_OUTPUT
+        # python packages do not support semantic versioning
+        NON_SEMVER_NEXT_VERSION="${NEXT_VERSION//-/}"
+
+        echo "current_version=${CURRENT_VERSION}" >>$GITHUB_OUTPUT
+        echo "next_version=${NEXT_VERSION}" >>$GITHUB_OUTPUT
+        echo "non_semver_next_version=${NON_SEMVER_NEXT_VERSION}" >>$GITHUB_OUTPUT
+        echo "is_latest=${IS_LATEST}" >>$GITHUB_OUTPUT


### PR DESCRIPTION
This PR:
1. introduces the `is_latest` variable, which indicates if a version is semantically latest compared to the latest git tag; useful for docker tagging.
2. fixes docker tags logic: latest will be added only for the latest release build; add "development" tag for images built from "development" branch