### PR TITLE
fix: use lts version for nodejs

### DIFF
--- a/.github/workflows/publish_gradle_docker.yml
+++ b/.github/workflows/publish_gradle_docker.yml
@@ -23,12 +23,12 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.4.0
+      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.5.0
 
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.5.0
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks }}
         run: |
@@ -43,13 +43,13 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.5.0
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0
 
   release:
     needs:
@@ -65,8 +65,8 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.4.0
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.5.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.5.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
            lfs: true
@@ -75,7 +75,7 @@ jobs:
         run: |
            sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
            ./gradlew build -x test
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.5.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_python_docker.yml
+++ b/.github/workflows/publish_python_docker.yml
@@ -23,7 +23,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -36,7 +36,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -56,7 +56,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.5.0
         id: semantic_versioning
 
   release:
@@ -73,7 +73,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.5.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.5.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
@@ -108,7 +108,7 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -116,6 +116,6 @@ jobs:
         shell: bash
         run: |
           poetry install --all-extras
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0
         with:
           bypass_checks: ${{ inputs.bypass_ort }}

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -31,7 +31,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -47,7 +47,7 @@ jobs:
       matrix:
         python-version: [ "3.11", "3.10", "3.9", "3.8" ]
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: "${{ matrix.python-version }}"
           install_poetry: true
@@ -60,13 +60,13 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
       - name: Install dependencies
         shell: bash
         run: |
           pip install poetry
           poetry install
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0
 
   calculate_version:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.5.0
         id: semantic_versioning
 
   release:
@@ -93,8 +93,8 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.4.0
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.5.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -122,7 +122,7 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run:
           make publish
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.5.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_vanilla_docker.yml
+++ b/.github/workflows/publish_vanilla_docker.yml
@@ -21,13 +21,13 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.5.0
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0
 
   release:
     needs:
@@ -41,11 +41,11 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.5.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.5.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_yarn_docker.yml
+++ b/.github/workflows/publish_yarn_docker.yml
@@ -19,7 +19,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.5.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -32,7 +32,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.5.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -51,18 +51,18 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@0.5.0
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
       - name: Install dependencies
         shell: bash
         run: |
           npm i
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0
 
   release:
     needs:
@@ -78,11 +78,11 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@0.5.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.5.0
         with:
           node_version: ${{ inputs.node_version }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
@@ -94,7 +94,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@0.5.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/test_gradle_docker.yml
+++ b/.github/workflows/test_gradle_docker.yml
@@ -27,12 +27,12 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.4.0
+      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@0.5.0
 
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.5.0
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks }}
         run: |
@@ -41,10 +41,10 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_java@0.5.0
       - name: Build
         run: ./gradlew build -x test
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -54,4 +54,4 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0

--- a/.github/workflows/test_python_docker.yml
+++ b/.github/workflows/test_python_docker.yml
@@ -27,7 +27,7 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -40,7 +40,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -66,7 +66,7 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -74,6 +74,6 @@ jobs:
         shell: bash
         run: |
           poetry install --all-extras
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0
         with:
           bypass_checks: ${{ inputs.bypass_ort }}

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -38,7 +38,7 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -54,7 +54,7 @@ jobs:
       matrix:
           python-version: ["3.11", "3.10", "3.9", "3.8"]
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: "${{ matrix.python-version }}"
           install_poetry: true
@@ -67,7 +67,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -91,10 +91,10 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
       - name: Install dependencies
         shell: bash
         run: |
           pip install poetry
           make build
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0

--- a/.github/workflows/test_vanilla_docker.yml
+++ b/.github/workflows/test_vanilla_docker.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -36,4 +36,4 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0

--- a/.github/workflows/test_yarn_docker.yml
+++ b/.github/workflows/test_yarn_docker.yml
@@ -24,7 +24,7 @@ jobs:
         uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f #v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.5.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -37,7 +37,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_node@0.5.0
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@0.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@0.5.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -63,9 +63,9 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@0.4.0
+      - uses: epam/ai-dial-ci/actions/prepare_python@0.5.0
       - name: Install dependencies
         shell: bash
         run: |
           npm i
-      - uses: epam/ai-dial-ci/actions/ort@0.4.0
+      - uses: epam/ai-dial-ci/actions/ort@0.5.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@0.4.0
+    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@0.5.0
     secrets: inherit
     with:
       bypass_checks: false

--- a/actions/gradle_checkstyle/action.yml
+++ b/actions/gradle_checkstyle/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: epam/ai-dial-ci/actions/prepare_java@0.4.0
+    - uses: epam/ai-dial-ci/actions/prepare_java@0.5.0
       with:
         java_version: ${{ inputs.java_version }}
         java_distribution: ${{ inputs.java_distribution }}

--- a/actions/prepare_node/action.yml
+++ b/actions/prepare_node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node_version:
     description: 'NodeJS version to use'
     required: false
-    default: '19'
+    default: '20'
   cache:
     description: 'Cache type. Supported values: npm, yarn, pnpm'
     required: false


### PR DESCRIPTION
Use lts version for nodejs which is stable and should be available in setup-node action manifest to prevent downloading from NodeJS official website
I'm trying to fix this issue - https://github.com/epam/ai-dial-chat/actions/runs/6667996296/job/18122596624#step:8:99
![image](https://github.com/epam/ai-dial-ci/assets/6322751/a0f5ddc4-c9b8-458d-bca4-d43dd4064d51)
