### PR TITLE
fix: use npm ci in github worflows

### DIFF
--- a/.github/workflows/publish_yarn_docker.yml
+++ b/.github/workflows/publish_yarn_docker.yml
@@ -26,7 +26,7 @@ jobs:
         continue-on-error: ${{ inputs.bypass_checks }}
         shell: bash
         run: |
-          npm i
+          npm ci
           yarn lint
 
   code_checks:
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: ${{ inputs.bypass_checks }}
         shell: bash
         run: |
-          npm i
+          npm ci
           yarn test --passWithNoTests
 
   calculate_version:
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          npm i
+          npm ci
       - uses: epam/ai-dial-ci/actions/ort@1.0.0
 
   release:

--- a/.github/workflows/test_yarn_docker.yml
+++ b/.github/workflows/test_yarn_docker.yml
@@ -31,7 +31,7 @@ jobs:
         continue-on-error: ${{ inputs.bypass_checks }}
         shell: bash
         run: |
-          npm i
+          npm ci
           yarn lint
 
   code_checks:
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: ${{ inputs.bypass_checks }}
         shell: bash
         run: |
-          npm i
+          npm ci
           yarn test --passWithNoTests
 
   docker_build:
@@ -67,5 +67,5 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          npm i
+          npm ci
       - uses: epam/ai-dial-ci/actions/ort@1.0.0


### PR DESCRIPTION
According to docs `npm ci` should be used in automated environments such as test platforms, continuous integration, and deployment
https://docs.npmjs.com/cli/v10/commands/npm-ci 