### PR TITLE
fix: proper release notes generation

### DIFF
--- a/.github/workflows/publish_gradle_docker.yml
+++ b/.github/workflows/publish_gradle_docker.yml
@@ -23,12 +23,12 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@1.0.1
+      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@1.0.2
 
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.2
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks }}
         run: |
@@ -44,13 +44,13 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.2
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2
 
   release:
     needs:
@@ -66,10 +66,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.2
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
-      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.2
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
            lfs: true
@@ -78,7 +78,7 @@ jobs:
         run: |
            sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
            ./gradlew build -x test
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -94,7 +94,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.2
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_gradle_docker.yml
+++ b/.github/workflows/publish_gradle_docker.yml
@@ -39,6 +39,7 @@ jobs:
     outputs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
+      latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     permissions:
       contents: write
       packages: write
@@ -66,6 +67,8 @@ jobs:
 
     steps:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+        with:
+          latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: epam/ai-dial-ci/actions/prepare_java@1.0.1
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:

--- a/.github/workflows/publish_python_docker.yml
+++ b/.github/workflows/publish_python_docker.yml
@@ -23,7 +23,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -36,7 +36,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -57,7 +57,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.2
         id: semantic_versioning
 
   release:
@@ -74,7 +74,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.2
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
@@ -85,7 +85,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.2
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
@@ -111,7 +111,7 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -119,6 +119,6 @@ jobs:
         shell: bash
         run: |
           poetry install --all-extras
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2
         with:
           bypass_checks: ${{ inputs.bypass_ort }}

--- a/.github/workflows/publish_python_docker.yml
+++ b/.github/workflows/publish_python_docker.yml
@@ -52,6 +52,7 @@ jobs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
+      latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     permissions:
       contents: write
       packages: write
@@ -74,6 +75,8 @@ jobs:
 
     steps:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+        with:
+          latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -72,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
+      latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     permissions:
       contents: write
       packages: write
@@ -94,6 +95,8 @@ jobs:
 
     steps:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+        with:
+          latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
         with:
           python_version: "${{ inputs.python_version }}"

--- a/.github/workflows/publish_python_package.yml
+++ b/.github/workflows/publish_python_package.yml
@@ -31,7 +31,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -47,7 +47,7 @@ jobs:
       matrix:
         python-version: [ "3.11", "3.10", "3.9", "3.8" ]
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: "${{ matrix.python-version }}"
           install_poetry: true
@@ -60,13 +60,13 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
       - name: Install dependencies
         shell: bash
         run: |
           pip install poetry
           poetry install
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2
 
   calculate_version:
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.2
         id: semantic_versioning
 
   release:
@@ -94,10 +94,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.2
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -125,7 +125,7 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run:
           make publish
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.2
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_vanilla_docker.yml
+++ b/.github/workflows/publish_vanilla_docker.yml
@@ -22,13 +22,13 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.2
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2
 
   release:
     needs:
@@ -42,13 +42,13 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.2
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.2
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_vanilla_docker.yml
+++ b/.github/workflows/publish_vanilla_docker.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
+      latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     permissions:
       contents: write
       packages: write
@@ -42,6 +43,8 @@ jobs:
 
     steps:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+        with:
+          latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true

--- a/.github/workflows/publish_yarn_docker.yml
+++ b/.github/workflows/publish_yarn_docker.yml
@@ -19,7 +19,7 @@ jobs:
   style_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.2
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -32,7 +32,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.2
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -52,18 +52,18 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.0.2
         id: semantic_versioning
 
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
       - name: Install dependencies
         shell: bash
         run: |
           npm i
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2
 
   release:
     needs:
@@ -79,13 +79,13 @@ jobs:
       packages: write
 
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.2
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.2
         with:
           node_version: ${{ inputs.node_version }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
@@ -97,7 +97,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -113,7 +113,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.0.2
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/publish_yarn_docker.yml
+++ b/.github/workflows/publish_yarn_docker.yml
@@ -47,6 +47,7 @@ jobs:
     outputs:
       next_version: ${{ steps.semantic_versioning.outputs.next_version }}
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
+      latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     permissions:
       contents: write
       packages: write
@@ -79,6 +80,8 @@ jobs:
 
     steps:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.0.1
+        with:
+          latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true

--- a/.github/workflows/test_gradle_docker.yml
+++ b/.github/workflows/test_gradle_docker.yml
@@ -27,12 +27,12 @@ jobs:
         uses: thehanimo/pr-title-checker@5652588c80c479af803eabfbdb5a3895a77c1388 #v1.4.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@1.0.1
+      - uses: epam/ai-dial-ci/actions/gradle_checkstyle@1.0.2
 
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.2
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks }}
         run: |
@@ -41,10 +41,10 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_java@1.0.2
       - name: Build
         run: ./gradlew build -x test
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -54,4 +54,4 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2

--- a/.github/workflows/test_python_docker.yml
+++ b/.github/workflows/test_python_docker.yml
@@ -27,7 +27,7 @@ jobs:
         uses: thehanimo/pr-title-checker@5652588c80c479af803eabfbdb5a3895a77c1388 #v1.4.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -40,7 +40,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -66,7 +66,7 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: ${{ inputs.python_version }}
           install_poetry: true
@@ -74,6 +74,6 @@ jobs:
         shell: bash
         run: |
           poetry install --all-extras
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2
         with:
           bypass_checks: ${{ inputs.bypass_ort }}

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -38,7 +38,7 @@ jobs:
         uses: thehanimo/pr-title-checker@5652588c80c479af803eabfbdb5a3895a77c1388 #v1.4.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -54,7 +54,7 @@ jobs:
       matrix:
           python-version: ["3.11", "3.10", "3.9", "3.8"]
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: "${{ matrix.python-version }}"
           install_poetry: true
@@ -67,7 +67,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
         with:
           python_version: "${{ inputs.python_version }}"
           install_poetry: true
@@ -91,10 +91,10 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
       - name: Install dependencies
         shell: bash
         run: |
           pip install poetry
           make build
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2

--- a/.github/workflows/test_vanilla_docker.yml
+++ b/.github/workflows/test_vanilla_docker.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -36,4 +36,4 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2

--- a/.github/workflows/test_yarn_docker.yml
+++ b/.github/workflows/test_yarn_docker.yml
@@ -24,7 +24,7 @@ jobs:
         uses: thehanimo/pr-title-checker@5652588c80c479af803eabfbdb5a3895a77c1388 #v1.4.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.2
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -37,7 +37,7 @@ jobs:
   code_checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_node@1.0.2
         with:
           node_version: ${{ inputs.node_version }}
       - name: Test
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.0.2
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test
@@ -63,9 +63,9 @@ jobs:
   ort:
     runs-on: ubuntu-latest
     steps:
-      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.1
+      - uses: epam/ai-dial-ci/actions/prepare_python@1.0.2
       - name: Install dependencies
         shell: bash
         run: |
           npm i
-      - uses: epam/ai-dial-ci/actions/ort@1.0.1
+      - uses: epam/ai-dial-ci/actions/ort@1.0.2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@1.0.1
+    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@1.0.2
     secrets: inherit
     with:
       bypass_checks: false

--- a/actions/generate_release_notes/action.yml
+++ b/actions/generate_release_notes/action.yml
@@ -1,5 +1,10 @@
-name: 'Generate release notes'
-description: 'Generate release notes based on conventional commits'
+name: "Generate release notes"
+description: "Generate release notes based on conventional commits"
+
+inputs:
+  latest_tag:
+    description: "Semantically latest git tag in the repository"
+    required: true
 
 runs:
   using: "composite"
@@ -12,70 +17,86 @@ runs:
     - name: Generate changelog
       id: generate_changelog
       shell: bash
+      env:
+        INPUT_LATEST_TAG: ${{ inputs.latest_tag }}
       run: |
-        #set -x
-        # ~12 hours spent on various attempts to re-use any of existing tools.
-        # most of them are sufficient for github flow (e.g. comparing changes against HEAD of default branch)
+        #!/bin/bash
 
-        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null|| echo NO )
+        # This script generates a changelog based on the commits since the last tag in the repository or the latest tag specified as an input.
+        # It categorizes the commits into features, fixes, and other changes.
+        # The script outputs the changelog to a file named my_changelog in the /tmp directory.
 
+        # set -x
+
+        latest_tag_repo="${INPUT_LATEST_TAG}"                                      # Trying to obtain the last tag if provided as ENV variable
+        latest_tag_branch=$(git describe --tags --abbrev=0 2>/dev/null || echo '') # Trying to obtain the latest GIT tag in the current branch
+
+        # Local branch tags should have priority.
+        # If no tags are found in both methods, it sets LAST_TAG as 'NO'
+        LAST_TAG="${latest_tag_branch:-${latest_tag_repo:-NO}}"
+
+        # Fetch all commit messages if no tags found, else fetch messages since the LAST_TAG
         if [[ "${LAST_TAG}" == "NO" ]]; then
-            git log  --pretty=format:"%s" > /tmp/my_commits_log_all
+            git log --pretty=format:"%s" >/tmp/my_commits_log
         else
-            git log "${LAST_TAG}"..HEAD --pretty=format:"%s" > /tmp/my_commits_log_all
+            git log "${LAST_TAG}"..HEAD --pretty=format:"%s" >/tmp/my_commits_log
         fi
 
-        cat /tmp/my_commits_log_all | sort > /tmp/my_commits_log
+        sort --unique --output /tmp/my_commits_log{,} # Sorting commits and removing duplicates
 
-        echo -n '' > /tmp/my_changelog_features
-        echo -n '' > /tmp/my_changelog_fixes
-        echo -n '' > /tmp/my_changelog_other
-        echo -n '' > /tmp/my_changelog
+        sed -i '/\[skip ci\] Update version/d' /tmp/my_commits_log # Removing '[skip ci] Update version' commits
 
+        # Creating empty files for each category.
+        echo -n '' >/tmp/my_changelog_features
+        echo -n '' >/tmp/my_changelog_fixes
+        echo -n '' >/tmp/my_changelog_other
+        echo -n '' >/tmp/my_changelog
+
+        # Regular expression patterns for categorizing commits
         FEATURES_REGEX="^feat:|^feature:"
         FIXES_REGEX="^fix:|^hotfix:"
 
-        { egrep "${FEATURES_REGEX}" /tmp/my_commits_log || echo -n '' ; } | while read l; do
-            DESCRIPTION=$(echo "${l}" | sed "s/^feat://;s/^feature://")
-            echo "* ${DESCRIPTION}" >> /tmp/my_changelog_features
-            export FEATURES_ENABLED=1
+        # Separating feature commits
+        { grep -E "${FEATURES_REGEX}" /tmp/my_commits_log || echo -n ''; } | while read -r l; do
+            DESCRIPTION=$(echo "${l}" | sed "s/^feat://;s/^feature://") # Removing leading keywords for neat display
+            echo "* ${DESCRIPTION}" >>/tmp/my_changelog_features
         done
 
-        { egrep "${FIXES_REGEX}" /tmp/my_commits_log || echo -n '' ; } | while read l; do
+        # Separating fix commits
+        { grep -E "${FIXES_REGEX}" /tmp/my_commits_log || echo -n ''; } | while read -r l; do
             DESCRIPTION=$(echo "${l}" | sed "s/^fix://;s/^hotfix://")
-            echo "* ${DESCRIPTION}" >> /tmp/my_changelog_fixes
-            export FIXES_ENABLED=1
+            echo "* ${DESCRIPTION}" >>/tmp/my_changelog_fixes
         done
 
-        { egrep -v "${FEATURES_REGEX}|${FIXES_REGEX}" /tmp/my_commits_log || echo -n '' ; } | while read l; do
-            echo "* ${l}" >> /tmp/my_changelog_other
-            export OTHER_ENABLED=1
+        # Separating other commits
+        { grep -Ev "${FEATURES_REGEX}|${FIXES_REGEX}" /tmp/my_commits_log || echo -n ''; } | while read -r l; do
+            echo "* ${l}" >>/tmp/my_changelog_other
         done
 
-        if [[ "$(wc -l < /tmp/my_changelog_features)" -gt 0 ]] ; then
-            echo "### Features:" >> /tmp/my_changelog
-            cat /tmp/my_changelog_features >> /tmp/my_changelog
-            echo "" >> /tmp/my_changelog
+        # Creating the final changelog file with markdown syntax
+        # features
+        if [[ "$(wc -l </tmp/my_changelog_features)" -gt 0 ]]; then
+            {
+                echo "### Features:"
+                cat /tmp/my_changelog_features
+                echo ""
+            } >>/tmp/my_changelog
         fi
 
-        if [[ "$(wc -l < /tmp/my_changelog_fixes)" -gt 0 ]] ; then
-            echo "### Fixes:" >> /tmp/my_changelog
-            cat /tmp/my_changelog_fixes >> /tmp/my_changelog
-            echo "" >> /tmp/my_changelog
+        # fixes
+        if [[ "$(wc -l </tmp/my_changelog_fixes)" -gt 0 ]]; then
+            {
+                echo "### Fixes:"
+                cat /tmp/my_changelog_fixes
+                echo ""
+            } >>/tmp/my_changelog
         fi
 
-        if [[ "$(wc -l  < /tmp/my_changelog_other)" -gt 0 ]] ; then
-            echo "### Other:" >> /tmp/my_changelog
-            grep -v "Merge branch " /tmp/my_changelog_other >> /tmp/my_changelog
-            echo "" >> /tmp/my_changelog
+        # other
+        if [[ "$(wc -l </tmp/my_changelog_other)" -gt 0 ]]; then
+            {
+                echo "### Other:"
+                grep -v "Merge branch " /tmp/my_changelog_other
+                echo ""
+            } >>/tmp/my_changelog
         fi
-
-        MY_CHANGELOG=$(cat /tmp/my_changelog)
-        MY_CHANGELOG="${MY_CHANGELOG//'%'/'%25'}"
-        MY_CHANGELOG="${MY_CHANGELOG//$'\n'/'%0A'}"
-        MY_CHANGELOG="${MY_CHANGELOG//$'\r'/'%0D'}"
-        {
-          echo "CHANGELOG<<EOF"
-          cat /tmp/my_changelog
-          echo "EOF"
-        } >> "$GITHUB_ENV"

--- a/actions/gradle_checkstyle/action.yml
+++ b/actions/gradle_checkstyle/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: epam/ai-dial-ci/actions/prepare_java@1.0.1
+    - uses: epam/ai-dial-ci/actions/prepare_java@1.0.2
       with:
         java_version: ${{ inputs.java_version }}
         java_distribution: ${{ inputs.java_distribution }}

--- a/actions/publish_tag_release/action.yml
+++ b/actions/publish_tag_release/action.yml
@@ -46,5 +46,5 @@ runs:
         allowUpdates: true
         updateOnlyUnreleased: true
         makeLatest: true
-        prerelease: false
+        draft: true
         tag: ${{ inputs.tag_version }}

--- a/actions/publish_tag_release/action.yml
+++ b/actions/publish_tag_release/action.yml
@@ -1,20 +1,20 @@
-name: 'Publish git tag and release'
-description: 'Commit changes back to git, apply tag and create release'
+name: "Publish git tag and release"
+description: "Commit changes back to git, apply tag and create release"
 inputs:
   extra_commit_command:
     description: 'Extra command to commit changes, e.g. `git add version.txt ; git commit -m "[skip ci] Update version" || true`'
     required: false
-    default: ''
+    default: ""
   tag_version:
-    description: 'Tag version'
+    description: "Tag version"
     required: true
   changelog_file:
-    description: 'Changelog file'
+    description: "Changelog file"
     required: true
   artifacts:
-    description: 'Artifacts to upload'
+    description: "Artifacts to upload"
     required: false
-    default: ''
+    default: ""
 
 runs:
   using: "composite"

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -1,19 +1,22 @@
-name: 'Calculate version'
-description: 'Calculate version based on semantic versioning @ conventional commits'
+name: "Calculate version"
+description: "Calculate version based on semantic versioning @ conventional commits"
 
 outputs:
   current_version:
-    description: 'Current version'
+    description: "Current version"
     value: ${{ steps.semantic.outputs.current_version }}
   next_version:
-    description: 'Next version'
+    description: "Next version"
     value: ${{ steps.semantic.outputs.next_version }}
   non_semver_next_version:
-    description: 'Next version without semantic versioning'
+    description: "Next version without semantic versioning"
     value: ${{ steps.semantic.outputs.non_semver_next_version }}
   is_latest:
-    description: 'Is a version semantically latest compared to the latest git tag?'
+    description: "Is a version semantically latest compared to the latest git tag?"
     value: ${{ steps.semantic.outputs.is_latest }}
+  latest_tag:
+    description: "Semantically latest git tag in the repository"
+    value: ${{ steps.semantic.outputs.latest_tag }}
 
 runs:
   using: "composite"
@@ -28,7 +31,7 @@ runs:
       shell: bash
       run: |
         #!/bin/bash
-        #set -x
+        # set -x
 
         function version { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
@@ -105,3 +108,4 @@ runs:
         echo "next_version=${NEXT_VERSION}" >>$GITHUB_OUTPUT
         echo "non_semver_next_version=${NON_SEMVER_NEXT_VERSION}" >>$GITHUB_OUTPUT
         echo "is_latest=${IS_LATEST}" >>$GITHUB_OUTPUT
+        echo "latest_tag=${LATEST_TAG}" >>$GITHUB_OUTPUT


### PR DESCRIPTION
This PR:
- fixes a commit scope the script uses while running on a `release-*`  branch without any tags
- adds unique commits filter
- adds `[skip ci] Update version` filter