### PR TITLE
fix: fixate twine version in CI

### DIFF
--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -91,7 +91,7 @@ jobs:
         continue-on-error: ${{ inputs.bypass_checks || inputs.bypass_code_checks }}
         shell: bash
         run: |
-          pip install twine
+          pip install twine==5.1.0
           make build
           twine check dist/*
           make test PYTHON=${{ matrix.python-version }}


### PR DESCRIPTION
Recently Twine has updated their version to `5.1.1`:
https://github.com/pypa/twine/pull/1114

Which contained this line in `pyproject`
```
	# workaround for #1116
	"pkginfo < 1.11",
```

This line breaks our CI, since poetry uses `pkginfo==1.11`
https://github.com/epam/ai-dial-sdk/actions/runs/9739951082/job/26876106056?pr=108
And somehow `3.10` version of Python can't handle that correctly



Currently Twine is working on fix: https://github.com/pypa/twine/pull/1123/files



But meanwhile, let's just fixate twine on version `5.1.0`