### PR TITLE
fix: downgrade twine to 5.0.0

### DIFF
--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -60,7 +60,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.3
         id: semantic_versioning
 
   release:
@@ -73,14 +73,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -45,6 +45,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.8.2
+      - uses: epam/ai-dial-ci/actions/ort@1.8.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -72,7 +72,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.3
         id: semantic_versioning
 
   release:
@@ -85,14 +85,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -100,7 +100,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.8.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.8.2
+      - uses: epam/ai-dial-ci/actions/ort@1.8.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Gradle"

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -81,7 +81,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.3
         id: semantic_versioning
 
   release:
@@ -94,14 +94,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: true
@@ -110,7 +110,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is_latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.8.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.8.2
+      - uses: epam/ai-dial-ci/actions/ort@1.8.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=NPM"

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -68,7 +68,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.3
         id: semantic_versioning
 
   release:
@@ -81,7 +81,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@1.8.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.8.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.8.2
+      - uses: epam/ai-dial-ci/actions/ort@1.8.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.3
         with:
           python_version: ${{ inputs.python_version }}
       - run: make build

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -63,7 +63,7 @@ jobs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.8.3
         id: semantic_versioning
 
   release:
@@ -76,14 +76,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.8.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Set version
@@ -97,7 +97,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.8.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -84,14 +84,14 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.8.3
         with:
           python_version: ${{ matrix.python-version }}
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks || inputs.bypass_code_checks }}
         shell: bash
         run: |
-          pip install twine==5.1.0
+          pip install twine==5.0.0
           make build
           twine check dist/*
           make test PYTHON=${{ matrix.python-version }}
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.8.2
+      - uses: epam/ai-dial-ci/actions/ort@1.8.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"


### PR DESCRIPTION
Even fixating twine at `5.1.0` causes some bugs 
```
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/twine/__init__.py", line 40, in <module>
    __uri__ = metadata["home-page"]
              ~~~~~~~~^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/importlib_metadata/_adapters.py", line 54, in __getitem__
    raise KeyError(item)
KeyError: 'home-page'
```


Latest working [version](https://github.com/epam/ai-dial-sdk/actions/runs/9681634405/job/26712670753) of twine in pipeline was `5.0.0`, let's fixate it for now on this version