### PR TITLE
fix: build.gradle version string regex to support formatting differences

### DIFF
--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -48,7 +48,7 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/build_docker@1.9.3

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -60,7 +60,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.3
         id: semantic_versioning
 
   release:
@@ -73,14 +73,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ inputs.enable_style_checks }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - name: Test
@@ -42,7 +42,7 @@ jobs:
     if: ${{ inputs.enable_ort }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/ort@1.9.3

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -45,6 +45,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.9.2
+      - uses: epam/ai-dial-ci/actions/ort@1.9.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -68,7 +68,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/java_prepare@1.9.3
@@ -80,7 +80,7 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/build_docker@1.9.3

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -72,7 +72,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.3
         id: semantic_versioning
 
   release:
@@ -85,14 +85,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -100,7 +100,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Set version
         shell: bash
         run: |
-          sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
+          sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
       - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
         with:
           ghcr_username: ${{ github.actor }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.9.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.9.2
+      - uses: epam/ai-dial-ci/actions/ort@1.9.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Gradle"

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -45,7 +45,7 @@ jobs:
     if: ${{ inputs.enable_style_checks }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/java_prepare@1.9.3
@@ -62,7 +62,7 @@ jobs:
     if: ${{ inputs.enable_code_checks }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/java_prepare@1.9.3
@@ -79,7 +79,7 @@ jobs:
     if: ${{ inputs.enable_ort }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/ort@1.9.3

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -73,7 +73,7 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/build_docker@1.9.3

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -81,7 +81,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.3
         id: semantic_versioning
 
   release:
@@ -94,14 +94,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: true
@@ -110,7 +110,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is_latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.9.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.9.2
+      - uses: epam/ai-dial-ci/actions/ort@1.9.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=NPM"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -49,7 +49,7 @@ jobs:
     if: ${{ inputs.enable_format_checks }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/node_prepare@1.9.3
@@ -66,7 +66,7 @@ jobs:
     if: ${{ inputs.enable_style_checks }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/node_prepare@1.9.3
@@ -83,7 +83,7 @@ jobs:
     if: ${{ inputs.enable_code_checks }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/node_prepare@1.9.3
@@ -100,7 +100,7 @@ jobs:
     if: ${{ inputs.enable_ort }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/ort@1.9.3

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,7 +10,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@cfb60706e18bc85e8aec535e3c577abe8f70378e # v5.5.2
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -63,7 +63,7 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/build_docker@1.9.3

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -68,7 +68,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.3
         id: semantic_versioning
 
   release:
@@ -81,7 +81,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@1.9.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.9.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.9.2
+      - uses: epam/ai-dial-ci/actions/ort@1.9.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ inputs.enable_style_checks }}
     runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
@@ -57,7 +57,7 @@ jobs:
     if: ${{ inputs.enable_code_checks }}
     runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
@@ -73,7 +73,7 @@ jobs:
     if: ${{ inputs.enable_ort }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/ort@1.9.3

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -70,7 +70,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
         with:
           python_version: ${{ inputs.python_version }}
       - run: make build

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -70,7 +70,7 @@ jobs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.9.3
         id: semantic_versioning
 
   release:
@@ -83,14 +83,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Set version
@@ -104,7 +104,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.9.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/generate_release_notes@1.9.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -65,7 +65,7 @@ jobs:
     if: ${{ inputs.enable_style_checks }}
     runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
@@ -85,7 +85,7 @@ jobs:
       matrix:
         python-version: ${{ fromJSON(inputs.test_python_versions) }}
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
@@ -104,7 +104,7 @@ jobs:
     if: ${{ inputs.enable_ort }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           lfs: true
       - uses: epam/ai-dial-ci/actions/ort@1.9.3

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.9.3
         with:
           python_version: ${{ matrix.python-version }}
       - name: Test
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/ort@1.9.2
+      - uses: epam/ai-dial-ci/actions/ort@1.9.3
         with:
           bypass_checks: ${{ inputs.bypass_checks || inputs.bypass_ort }}
           cli_args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Upload Trivy scan results to GitHub Security tab
         # Do not upload SARIF reports on private repos - GitHub Advanced Security is not enabled
         if: ${{ !cancelled() && inputs.enable_trivy && !github.event.repository.private }}
-        uses: github/codeql-action/upload-sarif@e2b3eafc8d227b0241d48be5f425d47c2d750a13 #v3.26.10
+        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b #v3.26.13
         with:
           sarif_file: "trivy-results.sarif"
           category: trivy

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Trivy vulnerability scanner (stdout, table view, no fail)
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -129,7 +129,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (SARIF, may fail)
         # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
         if: ${{ !github.event.repository.private }}
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -117,7 +117,7 @@ runs:
     - name: Upload Trivy scan results to GitHub Security tab
       # Do not upload SARIF reports on private repos - GitHub Advanced Security is not enabled
       if: ${{ !cancelled() && fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: github/codeql-action/upload-sarif@e2b3eafc8d227b0241d48be5f425d47c2d750a13 #v3.26.10
+      uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b #v3.26.13
       with:
         sarif_file: "trivy-results.sarif"
         category: trivy

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -88,7 +88,7 @@ runs:
           org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
     - name: Run Trivy vulnerability scanner (stdout, table view, no fail)
       if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "table"
@@ -101,7 +101,7 @@ runs:
     - name: Run Trivy vulnerability scanner (SARIF, may fail)
       # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
       if: ${{ fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "sarif"

--- a/actions/generate_release_notes/action.yml
+++ b/actions/generate_release_notes/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         fetch-depth: 0
         lfs: true

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
The change is to support different build.gradle file formats, e.g. all these cases should be supported

```groovy
version = "1.0.0"
```

```groovy
allprojects
{
version = '1.0.0'
}
```

```groovy
allprojects {
    version                          =     'huh'   # hello
}
```