### PR TITLE
feat: parametrize poetry version and default it to 1.8.5

### DIFF
--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -65,7 +65,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.3
         id: semantic_versioning
 
   release:
@@ -78,14 +78,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -65,7 +65,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
         id: semantic_versioning
 
   release:
@@ -78,14 +78,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -43,7 +43,7 @@ jobs:
           lfs: true
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -43,7 +43,7 @@ jobs:
           lfs: true
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -77,7 +77,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.3
         id: semantic_versioning
 
   release:
@@ -90,14 +90,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -105,7 +105,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -123,7 +123,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: gradle/actions/dependency-submission@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -77,7 +77,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
         id: semantic_versioning
 
   release:
@@ -90,14 +90,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -105,7 +105,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -123,7 +123,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: gradle/actions/dependency-submission@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.3
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -86,7 +86,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.3
         id: semantic_versioning
 
   release:
@@ -99,14 +99,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: true
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is_latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -86,7 +86,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
         id: semantic_versioning
 
   release:
@@ -99,14 +99,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: true
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is_latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.3
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "3.11"
         description: Python version to use
+      poetry_version:
+        type: string
+        description: "Poetry version to use"
+        default: "1.8.5"
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -64,6 +68,7 @@ jobs:
       bypass_ort: ${{ inputs.bypass_ort }}
       ort_version: ${{ inputs.ort_version }}
       python_version: ${{ inputs.python_version }}
+      poetry_version: ${{ inputs.poetry_version }}
 
   docker_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -78,7 +78,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.3
         id: semantic_versioning
 
   release:
@@ -91,7 +91,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.10.3
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -119,7 +119,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "3.11"
         description: Python version to use
+      poetry_version:
+        type: string
+        description: "Poetry version to use"
+        default: "1.8.5"
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -64,6 +68,7 @@ jobs:
       bypass_ort: ${{ inputs.bypass_ort }}
       ort_version: ${{ inputs.ort_version }}
       python_version: ${{ inputs.python_version }}
+      poetry_version: ${{ inputs.poetry_version }}
 
   calculate_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -73,7 +73,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
         id: semantic_versioning
 
   release:
@@ -86,7 +86,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -97,7 +97,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@1.10.2
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -114,7 +114,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.3
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.3
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -39,6 +39,10 @@ on:
         type: string
         default: "3.11"
         description: Python version to use
+      poetry_version:
+        type: string
+        description: "Poetry version to use"
+        default: "latest"
 
 jobs:
   style_checks:
@@ -51,6 +55,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
+          poetry_version: ${{ inputs.poetry_version }}
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks || inputs.bypass_style_checks }}
         shell: bash
@@ -67,6 +72,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
+          poetry_version: ${{ inputs.poetry_version }}
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks || inputs.bypass_code_checks }}
         shell: bash

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.3
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
       - run: make build

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "3.11"
         description: Python version to use
+      poetry_version:
+        type: string
+        description: "Poetry version to use"
+        default: "1.8.5"
       test_python_versions:
         type: string
         description: Python versions to run tests against
@@ -81,4 +85,5 @@ jobs:
       - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
+          poetry_version: ${{ inputs.poetry_version }}
       - run: make build

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -75,7 +75,7 @@ jobs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
         id: semantic_versioning
 
   release:
@@ -88,14 +88,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
       - name: Set version
@@ -109,7 +109,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -79,7 +79,7 @@ jobs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.10.3
         id: semantic_versioning
 
   release:
@@ -92,14 +92,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.10.3
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.3
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -114,7 +114,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.10.3
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "3.11"
         description: Python version to use
+      poetry_version:
+        type: string
+        description: "Poetry version to use"
+        default: "1.8.5"
       test_python_versions:
         type: string
         description: Python versions to run tests against
@@ -98,6 +102,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
+          poetry_version: ${{ inputs.poetry_version }}
       - name: Set version
         shell: bash
         run: |

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.3
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.3
         with:
           python_version: ${{ matrix.python-version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
       - name: Test
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.10.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ matrix.python-version }}
       - name: Test

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -59,6 +59,10 @@ on:
         type: string
         default: "3.11"
         description: Python version to use
+      poetry_version:
+        type: string
+        description: "Poetry version to use"
+        default: "latest"
       test_python_versions:
         type: string
         description: Python versions to run tests against
@@ -75,6 +79,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ inputs.python_version }}
+          poetry_version: ${{ inputs.poetry_version }}
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks || inputs.bypass_style_checks }}
         shell: bash
@@ -95,6 +100,7 @@ jobs:
       - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
         with:
           python_version: ${{ matrix.python-version }}
+          poetry_version: ${{ inputs.poetry_version }}
       - name: Test
         continue-on-error: ${{ inputs.bypass_checks || inputs.bypass_code_checks }}
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: mixed-line-ending

--- a/actions/python_prepare/action.yml
+++ b/actions/python_prepare/action.yml
@@ -11,6 +11,9 @@ inputs:
   install_poetry:
     description: "Install poetry"
     default: "true"
+  poetry_version:
+    description: "Poetry version to use"
+    default: "1.8.5"
 
 runs:
   using: "composite"
@@ -19,7 +22,7 @@ runs:
       if: ${{ fromJSON(inputs.install_poetry) }} # workaround for composite jobs not being able to pass boolean inputs
       shell: bash
       run: |
-        pip install poetry
+        pip install poetry==${{ inputs.poetry_version }}
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:

--- a/actions/python_prepare/action.yml
+++ b/actions/python_prepare/action.yml
@@ -4,7 +4,7 @@ description: "Checkout project, set up python"
 inputs:
   python_version:
     description: "Python version to use"
-    default: "3.11"
+    default: "3.x"
   cache:
     description: "Cache type. Supported values: pip, pipenv, poetry"
     default: "poetry"
@@ -13,7 +13,7 @@ inputs:
     default: "true"
   poetry_version:
     description: "Poetry version to use"
-    default: "1.8.5"
+    default: "latest"
 
 runs:
   using: "composite"

--- a/actions/python_prepare/action.yml
+++ b/actions/python_prepare/action.yml
@@ -18,11 +18,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install poetry
+    - name: Install Poetry
       if: ${{ fromJSON(inputs.install_poetry) }} # workaround for composite jobs not being able to pass boolean inputs
-      shell: bash
-      run: |
-        pip install poetry==${{ inputs.poetry_version }}
+      uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+        version: ${{ inputs.poetry_version }}
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:


### PR DESCRIPTION
Poetry 2.0.0 was released recently: https://github.com/python-poetry/poetry/releases/tag/2.0.0

`pip install poetry` in CI scripts installs the latest version.

Poetry 2.0.0 deprecates certain features from v1, so our Python projects are failing on CI during the sanity check with the deprecation warnings:

https://github.com/epam/ai-dial-sdk/actions/runs/12671721403/job/35314091486?pr=204#step:4:113

```
> poetry check --lock
Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.
Warning: [tool.poetry.version] is set but 'version' is not in [project.dynamic]. If it is static use [project.version]. If it is dynamic, add 'version' to [project.dynamic].
If you want to set the version dynamically via `poetry build --local-version` or you are using a plugin, which sets the version dynamically, you should define the version in [tool.poetry] and add 'version' to [project.dynamic].
Warning: [tool.poetry.description] is deprecated. Use [project.description] instead.
Warning: [tool.poetry.readme] is set but 'readme' is not in [project.dynamic]. If it is static use [project.readme]. If it is dynamic, add 'readme' to [project.dynamic].
If you want to define multiple readmes, you should define them in [tool.poetry] and add 'readme' to [project.dynamic].
Warning: [tool.poetry.license] is deprecated. Use [project.license] instead.
Warning: [tool.poetry.authors] is deprecated. Use [project.authors] instead.
Warning: [tool.poetry.homepage] is deprecated. Use [project.urls] instead.
Warning: [tool.poetry.repository] is deprecated. Use [project.urls] instead.
Warning: [tool.poetry.extras] is deprecated. Use [project.optional-dependencies] instead.
```

The fix allows us to specify the poetry version and also provides the default version 1.8.5 that works for our projects.