### PR TITLE
fix: remove persist-credentials option from checkout actions

### DIFF
--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -56,7 +56,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-          persist-credentials: false
       - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -65,7 +65,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.1
         id: semantic_versioning
 
   release:
@@ -78,14 +78,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.1
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.1
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-          persist-credentials: false
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass_checks || inputs.bypass_ort }} # Hack to use the input below as a boolean

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -44,7 +44,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
         with:

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.1
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -88,7 +88,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-          persist-credentials: false
       - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.1
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -77,7 +77,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.1
         id: semantic_versioning
 
   release:
@@ -90,14 +90,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.1
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.1
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -105,7 +105,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -123,7 +123,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: gradle/actions/dependency-submission@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.1
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.1
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.11.1
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -81,7 +81,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-          persist-credentials: false
       - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -86,7 +86,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.1
         id: semantic_versioning
 
   release:
@@ -99,14 +99,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.1
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.1
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: true
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is_latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.1
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.1
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.1
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.11.1
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -76,7 +76,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-          persist-credentials: false
       - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -78,7 +78,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.1
         id: semantic_versioning
 
   release:
@@ -91,7 +91,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.1
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.0
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -119,7 +119,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.1
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.1
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.1
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.1
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -79,7 +79,7 @@ jobs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.11.1
         id: semantic_versioning
 
   release:
@@ -92,14 +92,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.11.1
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.1
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -114,7 +114,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.11.1
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.1
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.11.1
         with:
           python_version: ${{ matrix.python-version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/actions/generate_release_notes/action.yml
+++ b/actions/generate_release_notes/action.yml
@@ -13,7 +13,6 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
-        persist-credentials: false
     - name: Generate changelog
       id: generate_changelog
       shell: bash

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -25,8 +25,6 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
-        persist-credentials: false
-
     - name: Calculate version
       id: semantic
       shell: bash

--- a/update-self-dependencies.sh
+++ b/update-self-dependencies.sh
@@ -1,6 +1,33 @@
 #!/bin/bash
 
-read -p "Enter the next (predicted) version tag (e.g., 1.0.1): " next_version
+# Get the latest tag, handling both v-prefixed and non-prefixed versions
+latest_tag=$(git tag --sort=-v:refname | grep -E "^v?[0-9]+\.[0-9]+\.[0-9]+$" | head -n1 | sed 's/^v//' )
+
+if [ -z "$latest_tag" ]; then
+    suggested_version="1.0.0"
+else
+    # Split version into parts
+    IFS='.' read -r major minor patch <<< "$latest_tag"
+
+    # Get the full tag name (with or without v prefix) for git log
+    full_tag=$(git tag --sort=-v:refname | grep -E "^v?${latest_tag}$" | head -n1)
+
+    # Analyze commits since last tag
+    git_log=$(git log "${full_tag}..HEAD" --pretty=format:"%s" 2>/dev/null || echo "")
+
+    # Check for keywords indicating feature additions
+    if [ -n "$git_log" ] && echo "$git_log" | grep -iE "feat:|feature:" > /dev/null; then
+        # Bump minor version for new features
+        suggested_version="$major.$((minor + 1)).0"
+    else
+        # Bump patch version for fixes and minor changes
+        suggested_version="$major.$minor.$((patch + 1))"
+    fi
+fi
+
+# Prompt user with the suggested version
+read -p "Enter the next version tag (suggested: $suggested_version): " next_version
+next_version=${next_version:-$suggested_version}
 
 # Define the search pattern
 search_pattern="epam/ai-dial-ci/"


### PR DESCRIPTION
What:
- remove `persist-credentials: false` option from checkout action invocations

Motivation:
- The current approach not working perfectly on private projects, e.g.
![image](https://github.com/user-attachments/assets/24a7d631-bb16-4b70-84b6-b3fad417d9e6)
- Additional testing is needed to add `persist-credentials: false` with awareness of private projects, caches, etc.