### PR TITLE
chore: add missing files for recommended community standards compliance

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,41 @@
+name: 🐞 Bug report
+description: Create a report to help us improve
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting an issue to improve DIAL.
+        Please fill in as much of the following form as you're able.
+  - type: input
+    attributes:
+      label: Name and Version
+      description: Application name and version
+      placeholder: dial 1.2.3
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What steps will reproduce the bug?
+      description: Enter details about your bug.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the expected behavior?
+      description: If possible please provide textual output instead of screenshots.
+  - type: textarea
+    attributes:
+      label: What do you see instead?
+      description: If possible please provide textual output instead of screenshots.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Tell us anything else you think we should know.

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,30 @@
+name: "🚀 Feature request"
+description: Suggest an idea for this project
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an idea to improve DIAL.
+        Please fill in as much of the following form as you're able.
+  - type: input
+    attributes:
+      label: Name and Version
+      description: Application name and version
+      placeholder: dial 1.2.3
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the problem this feature will solve?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the feature you are proposing to solve the problem?
+      description: Describe the requests. If you already have something in mind... PRs are welcome!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What alternatives have you considered?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: 📝 Talk in Discord
+    url: https://discord.com/channels/831132799535939614/1172686875299950683
+    about: Discuss your question in Discord

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+### Applicable issues
+
+<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
+- fixes #
+
+### Description of changes
+
+<!-- Please explain the changes you made right below this line. -->
+
+### Checklist
+
+<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
+
+- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Visual Studio Code
+.vscode/*
+.history/
+*.vsix
+
+# OSX
+.DS_Store
+
+.idea

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Reporting Security Issues
+
+We take all security reports seriously. We appreciate your efforts to responsibly disclose your findings and will make every effort to acknowledge your contributions.
+
+⚠️ Please do *not* file GitHub issues for security vulnerabilities as they are public! ⚠️
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/epam/ai-dial-ci/security/advisories/new) tab. Tip: In this form, only the title and description are mandatory.
+
+We will send a response indicating the next steps in handling your report. After the initial reply to your report, we will keep you informed of the progress toward a fix and full announcement and may ask for additional information or guidance.
+
+When we receive such reports, we will investigate and subsequently address any potential vulnerabilities as quickly as possible.


### PR DESCRIPTION
Add files, such as issue templates, as examples of how to comply with basic community standards