### PR TITLE
feat: improves trivy configuration for all release workflows

### DIFF
--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -35,6 +35,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: boolean
+        default: true
+        description: Limit severities for SARIF format
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -62,3 +70,5 @@ jobs:
           image_tag: test
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -38,7 +38,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -39,6 +39,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -71,4 +75,5 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -77,7 +77,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.12.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.13.0
         id: semantic_versioning
 
   release:
@@ -90,14 +90,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.12.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.13.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.12.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.13.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -105,6 +109,7 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Limit severities for SARIF format
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -96,6 +104,8 @@ jobs:
           push: true
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
             ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -48,8 +48,8 @@ on:
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to be displayed
       limit_severities_for_sarif_trivy:
-        type: string
-        default: "CRITICAL,HIGH"
+        type: boolean
+        default: true
         description: Limit severities for SARIF format
 
 env:

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -46,7 +46,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.13.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: boolean
+        default: true
+        description: Limit severities for SARIF format
       java_version:
         type: string
         default: "17"
@@ -94,3 +102,5 @@ jobs:
           image_tag: test
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -106,6 +110,7 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           gpr_username: ${{ github.actor }}
           gpr_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -46,7 +46,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.13.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -124,13 +124,10 @@ jobs:
           push: true
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
-<<<<<<< HEAD
           scan_severity: ${{ inputs.severity_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
-=======
           gpr_username: ${{ github.actor }}
           gpr_password: ${{ secrets.GITHUB_TOKEN }}
->>>>>>> main
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
             ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -125,6 +129,7 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           gpr_username: ${{ github.actor }}
           gpr_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Limit severities for SARIF format
       java_version:
         type: string
         default: "17"
@@ -116,6 +124,8 @@ jobs:
           push: true
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
             ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -46,7 +46,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -89,7 +89,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.12.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.13.0
         id: semantic_versioning
 
   release:
@@ -102,14 +102,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.12.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.13.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.13.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next_version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -140,7 +140,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: gradle/actions/dependency-submission@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.12.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.13.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -48,8 +48,8 @@ on:
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to be displayed
       limit_severities_for_sarif_trivy:
-        type: string
-        default: "CRITICAL,HIGH"
+        type: boolean
+        default: true
         description: Limit severities for SARIF format
       java_version:
         type: string

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.13.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@1.13.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@51f4b93cb23c90c36a401cbb154b0dc2bc497c84
+      - uses: epam/ai-dial-ci/actions/build_docker@b07a1e9c3dde76e22baac63f93f45b99b5d27e8f
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
+      - uses: epam/ai-dial-ci/actions/build_docker@51f4b93cb23c90c36a401cbb154b0dc2bc497c84
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@abe45c81680274aca262b48b23258ec81558844a
+      - uses: epam/ai-dial-ci/actions/build_docker@3b818138a9e3db565a9926dee4b98d50d8a84266
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -55,6 +55,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -96,4 +100,5 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@b07a1e9c3dde76e22baac63f93f45b99b5d27e8f
+      - uses: epam/ai-dial-ci/actions/build_docker@f1de85147fd3b03ea34b10596b3e116b4d9a40ed
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@3b818138a9e3db565a9926dee4b98d50d8a84266
+      - uses: epam/ai-dial-ci/actions/build_docker@229993613f363b37f7a2344958944f4b3e99944f
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@51f4b93cb23c90c36a401cbb154b0dc2bc497c84
+      - uses: epam/ai-dial-ci/actions/build_docker@1.11.1
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -51,6 +51,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: boolean
+        default: true
+        description: Limit severities for SARIF format
       node_version:
         type: string
         default: "20"
@@ -87,3 +95,5 @@ jobs:
           image_tag: test
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@adcf94bba86d7a68741796fecf298d5f19db454a
+      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@adcf94bba86d7a68741796fecf298d5f19db454a
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -54,7 +54,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@229993613f363b37f7a2344958944f4b3e99944f
+      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@abe45c81680274aca262b48b23258ec81558844a
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -51,6 +51,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Limit severities for SARIF format
       enable_publish:
         type: boolean
         default: true
@@ -126,6 +134,8 @@ jobs:
           push: true
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
             ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -98,7 +98,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.12.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.13.0
         id: semantic_versioning
 
   release:
@@ -111,14 +111,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.12.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.13.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.13.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: true
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next_version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -170,7 +170,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is_latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.12.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.13.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -56,8 +56,8 @@ on:
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to be displayed
       limit_severities_for_sarif_trivy:
-        type: string
-        default: "CRITICAL,HIGH"
+        type: boolean
+        default: true
         description: Limit severities for SARIF format
       enable_publish:
         type: boolean

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -54,7 +54,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -55,6 +55,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -135,6 +139,7 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.13.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.13.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@1.13.0
         with:
           node_version: ${{ inputs.node_version }}
           clean_install: "true"

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: boolean
+        default: true
+        description: Limit severities for SARIF format
       python_version:
         type: string
         default: "3.11"
@@ -82,3 +90,5 @@ jobs:
           image_tag: test
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           image_name: ghcr.io/${{ env.IMAGE_NAME }}
           image_tag: test

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -46,7 +46,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -91,4 +95,5 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -90,7 +90,7 @@ jobs:
       is_latest: ${{ steps.semantic_versioning.outputs.is_latest }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.12.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.13.0
         id: semantic_versioning
 
   release:
@@ -103,7 +103,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.12.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.13.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -114,7 +114,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.non_semver_next_version }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@1.12.1
+      - uses: epam/ai-dial-ci/actions/build_docker@1.13.0
         with:
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -134,7 +134,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is_latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.12.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.13.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Limit severities for SARIF format
       python_version:
         type: string
         default: "3.11"
@@ -113,6 +121,8 @@ jobs:
           push: true
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
+          scan_severity: ${{ inputs.severity_trivy }}
+          scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}
             ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -122,6 +126,7 @@ jobs:
           scan: ${{ inputs.enable_trivy }}
           bypass_checks: ${{ inputs.bypass_trivy }}
           scan_severity: ${{ inputs.severity_trivy }}
+          scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
           scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
           image_extra_aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next_version }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -46,7 +46,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -48,8 +48,8 @@ on:
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to be displayed
       limit_severities_for_sarif_trivy:
-        type: string
-        default: "CRITICAL,HIGH"
+        type: boolean
+        default: true
         description: Limit severities for SARIF format
       python_version:
         type: string

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.13.0
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.13.0
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.13.0
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -46,7 +46,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: boolean
+        default: true
+        description: Limit severities for SARIF format
       python_version:
         type: string
         default: "3.11"
@@ -73,6 +81,8 @@ jobs:
       ort_version: ${{ inputs.ort_version }}
       enable_trivy: ${{ inputs.enable_trivy }}
       bypass_trivy: ${{ inputs.bypass_trivy }}
+      scan_severity: ${{ inputs.severity_trivy }}
+      scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
       python_version: ${{ inputs.python_version }}
       test_python_versions: ${{ inputs.test_python_versions }}
 

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -82,6 +86,7 @@ jobs:
       enable_trivy: ${{ inputs.enable_trivy }}
       bypass_trivy: ${{ inputs.bypass_trivy }}
       scan_severity: ${{ inputs.severity_trivy }}
+      scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
       scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
       python_version: ${{ inputs.python_version }}
       test_python_versions: ${{ inputs.test_python_versions }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if Trivy failed
+      severity_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Severities of vulnerabilities to be displayed
+      limit_severities_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Limit severities for SARIF format
       python_version:
         type: string
         default: "3.11"
@@ -70,6 +78,8 @@ jobs:
       ort_version: ${{ inputs.ort_version }}
       enable_trivy: ${{ inputs.enable_trivy }}
       bypass_trivy: ${{ inputs.bypass_trivy }}
+      scan_severity: ${{ inputs.severity_trivy }}
+      scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
       python_version: ${{ inputs.python_version }}
       test_python_versions: ${{ inputs.test_python_versions }}
 

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -46,7 +46,7 @@ on:
       severity_trivy:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       limit_severities_for_sarif_trivy:
         type: boolean
         default: true
@@ -79,6 +83,7 @@ jobs:
       enable_trivy: ${{ inputs.enable_trivy }}
       bypass_trivy: ${{ inputs.bypass_trivy }}
       scan_severity: ${{ inputs.severity_trivy }}
+      scan_severity_for_sarif: ${{ inputs.severity_for_sarif_trivy }}
       scan_limit_severities_for_sarif: ${{ inputs.limit_severities_for_sarif_trivy }}
       python_version: ${{ inputs.python_version }}
       test_python_versions: ${{ inputs.test_python_versions }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -48,8 +48,8 @@ on:
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to be displayed
       limit_severities_for_sarif_trivy:
-        type: string
-        default: "CRITICAL,HIGH"
+        type: boolean
+        default: true
         description: Limit severities for SARIF format
       python_version:
         type: string

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -94,7 +94,7 @@ jobs:
       non_semver_next_version: ${{ steps.semantic_versioning.outputs.non_semver_next_version }}
       latest_tag: ${{ steps.semantic_versioning.outputs.latest_tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.12.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@1.13.0
         id: semantic_versioning
 
   release:
@@ -107,14 +107,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.12.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@1.13.0
         with:
           latest_tag: ${{ needs.calculate_version.outputs.latest_tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.13.0
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -129,7 +129,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.12.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@1.13.0
         with:
           tag_version: ${{ needs.calculate_version.outputs.non_semver_next_version }}
           changelog_file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.13.0
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@1.12.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@1.13.0
         with:
           python_version: ${{ matrix.python-version }}
           poetry_version: ${{ inputs.poetry_version }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -35,6 +35,10 @@ on:
         type: string
         default: "CRITICAL,HIGH"
         description: Severities of vulnerabilities to fail the build
+      severity_for_sarif_trivy:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities in SARIF report"
       scan_limit_severities_for_sarif:
         type: boolean
         default: true

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Trivy vulnerability scanner (stdout, table view, no fail)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@7aca5acc9500b463826cc47a47a65ad7d404b045 # TODO: v0.31.0+
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -155,7 +155,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (SARIF, may fail)
         # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
         if: ${{ !github.event.repository.private }}
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@7aca5acc9500b463826cc47a47a65ad7d404b045 # TODO: v0.31.0+
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -34,7 +34,7 @@ on:
       scan_severity:
         type: string
         default: "CRITICAL,HIGH"
-        description: Severities of vulnerabilities to be displayed
+        description: Severities of vulnerabilities to fail the build
       scan_limit_severities_for_sarif:
         type: boolean
         default: true

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -32,9 +32,13 @@ on:
         default: false
         description: Do not fail pipeline if Trivy failed
       scan_severity:
-        description: "Severity of vulnerabilities to fail the build"
         type: string
         default: "CRITICAL,HIGH"
+        description: "Severities of vulnerabilities to be displayed"
+      scan_limit_severities_for_sarif:
+        type: string
+        default: "CRITICAL,HIGH"
+        description: Limit severities for SARIF format
       scan_vuln_type:
         description: "Type of vulnerabilities to scan"
         type: string
@@ -140,6 +144,7 @@ jobs:
           ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
           vuln-type: ${{ inputs.scan_vuln_type }}
           severity: ${{ inputs.scan_severity }}
+          limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
         continue-on-error: ${{ inputs.bypass_trivy }}
         env:
           TRIVY_DISABLE_VEX_NOTICE: true
@@ -156,7 +161,7 @@ jobs:
           ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
           vuln-type: ${{ inputs.scan_vuln_type }}
           severity: ${{ inputs.scan_severity }}
-          limit-severities-for-sarif: true
+          limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
         continue-on-error: ${{ inputs.bypass_trivy }}
         env:
           TRIVY_DISABLE_VEX_NOTICE: true

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -34,10 +34,10 @@ on:
       scan_severity:
         type: string
         default: "CRITICAL,HIGH"
-        description: "Severities of vulnerabilities to be displayed"
+        description: Severities of vulnerabilities to be displayed
       scan_limit_severities_for_sarif:
-        type: string
-        default: "CRITICAL,HIGH"
+        type: boolean
+        default: true
         description: Limit severities for SARIF format
       scan_vuln_type:
         description: "Type of vulnerabilities to scan"

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -145,6 +145,7 @@ runs:
         TRIVY_SKIP_JAVA_DB_UPDATE: true # We already have the Java DB updated just above
         TRIVY_DISABLE_VEX_NOTICE: true
         TRIVY_FORMAT: "table"
+        TRIVY_OUTPUT: ""
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Build and push
       if: ${{ fromJSON(inputs.push) }} # workaround for composite jobs not being able to pass boolean inputs

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -94,14 +94,14 @@ runs:
         DOCKER_BUILD_RECORD_UPLOAD: false
     - name: Run Trivy vulnerability scanner (stdout, table view, no fail)
       if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+      uses: aquasecurity/trivy-action@0.30.0
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "table"
+        exit-code: "1"
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
         severity: ${{ inputs.scan_severity }}
-        limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
       env:
         CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
         TRIVY_DISABLE_VEX_NOTICE: true
@@ -109,16 +109,14 @@ runs:
     - name: Run Trivy vulnerability scanner (SARIF, may fail)
       # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
       if: ${{ fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+      uses: aquasecurity/trivy-action@0.30.0
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "sarif"
         output: "trivy-results.sarif"
-        exit-code: "1"
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
-        severity: ${{ inputs.scan_severity }}
-        limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
+        limit-severities-for-sarif: false
         skip-setup-trivy: true # We already have trivy installed just above
       env:
         TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above
@@ -128,7 +126,7 @@ runs:
     - name: Upload Trivy scan results to GitHub Security tab
       # Do not upload SARIF reports on private repos - GitHub Advanced Security is not enabled
       if: ${{ !cancelled() && fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 #v3.28.0
+      uses: github/codeql-action/upload-sarif@v3 #v3.28.0
       with:
         sarif_file: "trivy-results.sarif"
         category: trivy

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -92,7 +92,7 @@ runs:
           org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
       env:
         DOCKER_BUILD_RECORD_UPLOAD: false
-    - name: Run Trivy vulnerability scanner (SARIF, no fail)
+    - name: Run Trivy vulnerability scanner (SARIF, all severities, no fail)
       # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
       if: ${{ fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
       uses: aquasecurity/trivy-action@0.30.0
@@ -103,21 +103,21 @@ runs:
         output: "trivy-results.sarif"
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
-        limit-severities-for-sarif: false
+        limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
       env:
         CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Upload Trivy scan results to GitHub Security tab
       # Do not upload SARIF reports on private repos - GitHub Advanced Security is not enabled
       if: ${{ !cancelled() && fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: github/codeql-action/upload-sarif@v3 #v3.28.0
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: "trivy-results.sarif"
         category: trivy
       env:
         CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
-    - name: Run Trivy vulnerability scanner (stdout, table view, may fail)
+    - name: Run Trivy vulnerability scanner (stdout, table view, chosen severities, may fail)
       if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
       uses: aquasecurity/trivy-action@0.30.0
       with:

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Severities of vulnerabilities to fail the build"
     required: false
     default: "CRITICAL,HIGH"
+  scan_severity_for_sarif:
+    description: "Severities of vulnerabilities in SARIF report"
+    required: false
+    default: "CRITICAL,HIGH"
   scan_limit_severities_for_sarif:
     description: "Limit severities for SARIF format"
     required: false
@@ -114,7 +118,7 @@ runs:
         output: "trivy-results.sarif"
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
-        severity: ${{ inputs.scan_severity }}
+        severity: ${{ inputs.scan_severity_for_sarif }}
         limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
       env:
         TRIVY_DISABLE_VEX_NOTICE: true

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -103,7 +103,7 @@ runs:
           GPR_PASSWORD=${{ inputs.gpr_password }}
       env:
         DOCKER_BUILD_RECORD_UPLOAD: false
-    - name: Run Trivy vulnerability scanner (SARIF, all severities, no fail)
+    - name: Run Trivy vulnerability scanner (SARIF, no fail)
       # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
       if: ${{ fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
       uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
@@ -114,10 +114,11 @@ runs:
         output: "trivy-results.sarif"
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
+        severity: ${{ inputs.scan_severity }}
         limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
       env:
-        CONTINUE_ON_ERROR: true # Hack to use the input below as a boolean
-      continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
+        TRIVY_DISABLE_VEX_NOTICE: true
+      continue-on-error: true # Alongside with `exit-code: 0`, ensure not failing the workflow
     - name: Upload Trivy scan results to GitHub Security tab
       # Do not upload SARIF reports on private repos - GitHub Advanced Security is not enabled
       if: ${{ !cancelled() && fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
@@ -128,7 +129,7 @@ runs:
       env:
         CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
-    - name: Run Trivy vulnerability scanner (stdout, table view, chosen severities, may fail)
+    - name: Run Trivy vulnerability scanner (stdout, table view, may fail)
       if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
       uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
       with:
@@ -144,8 +145,6 @@ runs:
         TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above
         TRIVY_SKIP_JAVA_DB_UPDATE: true # We already have the Java DB updated just above
         TRIVY_DISABLE_VEX_NOTICE: true
-        TRIVY_FORMAT: "table"
-        TRIVY_OUTPUT: ""
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Build and push
       if: ${{ fromJSON(inputs.push) }} # workaround for composite jobs not being able to pass boolean inputs

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -135,7 +135,7 @@ runs:
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Run Trivy vulnerability scanner (stdout, table view, may fail)
       if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # TODO: v0.31.0+
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "table"
@@ -149,6 +149,8 @@ runs:
         TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above
         TRIVY_SKIP_JAVA_DB_UPDATE: true # We already have the Java DB updated just above
         TRIVY_DISABLE_VEX_NOTICE: true
+        TRIVY_FORMAT: "table" # TODO: remove after fix in aquasecurity/trivy-action
+        TRIVY_OUTPUT: "" # TODO: remove after fix in aquasecurity/trivy-action
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Build and push
       if: ${{ fromJSON(inputs.push) }} # workaround for composite jobs not being able to pass boolean inputs

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -19,7 +19,7 @@ inputs:
   scan_limit_severities_for_sarif:
     description: "Limit severities for SARIF format"
     required: false
-    default: "CRITICAL,HIGH"
+    default: "true"
   scan_vuln_type:
     description: "Type of vulnerabilities to scan"
     required: false

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -116,7 +116,7 @@ runs:
         vuln-type: ${{ inputs.scan_vuln_type }}
         limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
       env:
-        CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
+        CONTINUE_ON_ERROR: true # Hack to use the input below as a boolean
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Upload Trivy scan results to GitHub Security tab
       # Do not upload SARIF reports on private repos - GitHub Advanced Security is not enabled
@@ -144,6 +144,7 @@ runs:
         TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above
         TRIVY_SKIP_JAVA_DB_UPDATE: true # We already have the Java DB updated just above
         TRIVY_DISABLE_VEX_NOTICE: true
+        TRIVY_FORMAT: "table"
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Build and push
       if: ${{ fromJSON(inputs.push) }} # workaround for composite jobs not being able to pass boolean inputs

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -13,7 +13,11 @@ inputs:
     required: false
     default: "true"
   scan_severity:
-    description: "Severity of vulnerabilities to fail the build"
+    description: "Severities of vulnerabilities to be displayed"
+    required: false
+    default: "CRITICAL,HIGH"
+  scan_limit_severities_for_sarif:
+    description: "Limit severities for SARIF format"
     required: false
     default: "CRITICAL,HIGH"
   scan_vuln_type:
@@ -97,6 +101,7 @@ runs:
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
         severity: ${{ inputs.scan_severity }}
+        limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
       env:
         CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
         TRIVY_DISABLE_VEX_NOTICE: true
@@ -113,7 +118,7 @@ runs:
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
         severity: ${{ inputs.scan_severity }}
-        limit-severities-for-sarif: true
+        limit-severities-for-sarif: ${{ inputs.scan_limit_severities_for_sarif }}
         skip-setup-trivy: true # We already have trivy installed just above
       env:
         TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -110,7 +110,7 @@ runs:
     - name: Run Trivy vulnerability scanner (SARIF, no fail)
       # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
       if: ${{ fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+      uses: aquasecurity/trivy-action@7aca5acc9500b463826cc47a47a65ad7d404b045 # TODO: v0.31.0+
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "sarif"
@@ -135,7 +135,7 @@ runs:
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Run Trivy vulnerability scanner (stdout, table view, may fail)
       if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # TODO: v0.31.0+
+      uses: aquasecurity/trivy-action@7aca5acc9500b463826cc47a47a65ad7d404b045 # TODO: v0.31.0+
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "table"
@@ -149,8 +149,6 @@ runs:
         TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above
         TRIVY_SKIP_JAVA_DB_UPDATE: true # We already have the Java DB updated just above
         TRIVY_DISABLE_VEX_NOTICE: true
-        TRIVY_FORMAT: "table" # TODO: remove after fix in aquasecurity/trivy-action
-        TRIVY_OUTPUT: "" # TODO: remove after fix in aquasecurity/trivy-action
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Build and push
       if: ${{ fromJSON(inputs.push) }} # workaround for composite jobs not being able to pass boolean inputs

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: "true"
   scan_severity:
-    description: "Severities of vulnerabilities to be displayed"
+    description: "Severities of vulnerabilities to fail the build"
     required: false
     default: "CRITICAL,HIGH"
   scan_limit_severities_for_sarif:
@@ -106,7 +106,7 @@ runs:
     - name: Run Trivy vulnerability scanner (SARIF, all severities, no fail)
       # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
       if: ${{ fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@0.30.0
+      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "sarif"
@@ -121,7 +121,7 @@ runs:
     - name: Upload Trivy scan results to GitHub Security tab
       # Do not upload SARIF reports on private repos - GitHub Advanced Security is not enabled
       if: ${{ !cancelled() && fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 #v3.28.0
       with:
         sarif_file: "trivy-results.sarif"
         category: trivy
@@ -130,7 +130,7 @@ runs:
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Run Trivy vulnerability scanner (stdout, table view, chosen severities, may fail)
       if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@0.30.0
+      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "table"

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -92,35 +92,19 @@ runs:
           org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
       env:
         DOCKER_BUILD_RECORD_UPLOAD: false
-    - name: Run Trivy vulnerability scanner (stdout, table view, no fail)
-      if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
-      uses: aquasecurity/trivy-action@0.30.0
-      with:
-        image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
-        format: "table"
-        exit-code: "1"
-        ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
-        vuln-type: ${{ inputs.scan_vuln_type }}
-        severity: ${{ inputs.scan_severity }}
-      env:
-        CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
-        TRIVY_DISABLE_VEX_NOTICE: true
-      continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
-    - name: Run Trivy vulnerability scanner (SARIF, may fail)
+    - name: Run Trivy vulnerability scanner (SARIF, no fail)
       # Do not perform SARIF scan on private repos - GitHub Advanced Security is not enabled
       if: ${{ fromJSON(inputs.scan) && !github.event.repository.private }} # workaround for composite jobs not being able to pass boolean inputs
       uses: aquasecurity/trivy-action@0.30.0
       with:
         image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         format: "sarif"
+        exit-code: "0"
         output: "trivy-results.sarif"
         ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
         vuln-type: ${{ inputs.scan_vuln_type }}
         limit-severities-for-sarif: false
-        skip-setup-trivy: true # We already have trivy installed just above
       env:
-        TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above
-        TRIVY_SKIP_JAVA_DB_UPDATE: true # We already have the Java DB updated just above
         CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Upload Trivy scan results to GitHub Security tab
@@ -132,6 +116,23 @@ runs:
         category: trivy
       env:
         CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
+      continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
+    - name: Run Trivy vulnerability scanner (stdout, table view, may fail)
+      if: ${{ fromJSON(inputs.scan) }} # workaround for composite jobs not being able to pass boolean inputs
+      uses: aquasecurity/trivy-action@0.30.0
+      with:
+        image-ref: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
+        format: "table"
+        exit-code: "1"
+        ignore-unfixed: ${{ inputs.scan_ignore_unfixed }}
+        vuln-type: ${{ inputs.scan_vuln_type }}
+        severity: ${{ inputs.scan_severity }}
+        skip-setup-trivy: true # We already have trivy installed just above
+      env:
+        CONTINUE_ON_ERROR: ${{ inputs.bypass_checks }} # Hack to use the input below as a boolean
+        TRIVY_SKIP_DB_UPDATE: true # We already have the DB updated just above
+        TRIVY_SKIP_JAVA_DB_UPDATE: true # We already have the Java DB updated just above
+        TRIVY_DISABLE_VEX_NOTICE: true
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
     - name: Build and push
       if: ${{ fromJSON(inputs.push) }} # workaround for composite jobs not being able to pass boolean inputs


### PR DESCRIPTION
**Added:** option to override 'severity' of vulnerabilities to be displayed in trivy scan results
**Added:** option to override 'limit-severities-for-sarif ' for trivy scans
**Changed:** trivy scan runs in 3 steps: 

- scan produces sarif report with option to display all vulnerabilities (depends on  'limit-severities-for-sarif ' property). will never fail
- uploads sarif report to view it on 'Security' tab
- scans for limited 'severities' and fails if vulnerabilities found and continue_on_error is false