### PR TITLE
hotfix: enable LFS support in generate_release_notes action to fix subsequent checkouts

### DIFF
--- a/actions/generate_release_notes/action.yml
+++ b/actions/generate_release_notes/action.yml
@@ -13,6 +13,10 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
+        # HACK: there's a bug in actions/checkout, where all subsequent checkouts within single job with `lfs: true`
+        # doesn't actually fetch LFS files. So, we have to use lfs even we don't need it here.
+        # ref: https://github.com/actions/checkout/issues/270
+        lfs: true
     - name: Generate changelog
       id: generate_changelog
       shell: bash

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -25,10 +25,6 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
-        # HACK: there's a bug in actions/checkout, where all subsequent checkouts within single job with `lfs: true`
-        # doesn't actually fetch LFS files. So, we have to use lfs even we don't need it here.
-        # ref: https://github.com/actions/checkout/issues/270
-        lfs: true
     - name: Calculate version
       id: semantic
       shell: bash


### PR DESCRIPTION
### Description of changes

There's a bug in actions/checkout, where all subsequent checkouts within single job with `lfs: true`.
It doesn't actually fetch LFS files. So, we have to use lfs even we don't need it here.
See https://github.com/actions/checkout/issues/270


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
