### PR TITLE
fix: untagged multi-arch images cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,13 +290,9 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03 # v3.0.0
+      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          account: ${{ github.repository_owner }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: ${{ github.event.repository.name }}
-          tag-selection: "untagged"
-          cut-off: "1d"
+          delete-untagged: true
 ```
 
 ### Dependency Review (Java (gradle))


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->

Use `dataaxiom/ghcr-cleanup-action` action to properly cleanup untagged multi-arch images in GHCR.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
