### PR TITLE
feat: replace action for posting a comment in java dependency review workflow

### DIFF
--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -70,6 +70,5 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          header: dependency-analysis
           body-path: openssf-report.html
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -62,12 +62,14 @@ jobs:
         with:
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 600
-          show-openssf-scorecard: ${{ inputs.show_openssf_scorecard }}
+      - if: ${{ steps.dependency-review.outputs.comment-content != null }}
+        run: |
+          printf "%s" "${{ steps.dependency-review.outputs.comment-content }}" > openssf-report.html
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
         # Use separate action to comment because the original one can't do it without PR context
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
-          number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request.number }}
           header: dependency-analysis
-          message: ${{ steps.dependency-review.outputs.comment-content }}
+          body-path: openssf-report.html
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -59,10 +59,8 @@ jobs:
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 600
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
-        env:
-          COMMENT_CONTENT: ${{ steps.dependency-review.outputs.comment-content }}
         run: |
-          echo "${COMMENT_CONTENT}" > openssf-report.html
+          echo "${{ steps.dependency-review.outputs.comment-content }}" > openssf-report.html
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
         # Use separate action to comment because the original one can't do it without PR context
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -12,10 +12,6 @@ on:
         type: string
         default: "temurin"
         description: Java distribution to use
-      show_openssf_scorecard:
-        type: boolean
-        default: true
-        description: Show Openssf Scorecard scores for the dependencies changed in this pull request
     secrets:
       ACTIONS_BOT_TOKEN:
         required: true

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -59,12 +59,15 @@ jobs:
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 600
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
+        env:
+          COMMENT_CONTENT: ${{ steps.dependency-review.outputs.comment-content }}
         run: |
-          printf "%s" "${{ steps.dependency-review.outputs.comment-content }}" > openssf-report.html
+          printf "%s" "${COMMENT_CONTENT}" > openssf-report.html
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
         # Use separate action to comment because the original one can't do it without PR context
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: openssf-report.html
+          edit-mode: replace
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -12,6 +12,10 @@ on:
         type: string
         default: "temurin"
         description: Java distribution to use
+      show_openssf_scorecard:
+        type: boolean
+        default: true
+        description: Show Openssf Scorecard scores for the dependencies changed in this pull request
     secrets:
       ACTIONS_BOT_TOKEN:
         required: true
@@ -58,6 +62,7 @@ jobs:
         with:
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 600
+          show-openssf-scorecard: ${{ inputs.show_openssf_scorecard }}
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
         # Use separate action to comment because the original one can't do it without PR context
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           COMMENT_CONTENT: ${{ steps.dependency-review.outputs.comment-content }}
         run: |
-          printf "%s" "${COMMENT_CONTENT}" > openssf-report.html
+          echo "${COMMENT_CONTENT}" > openssf-report.html
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
         # Use separate action to comment because the original one can't do it without PR context
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- replace `marocchino/sticky-pull-request-comment` with `peter-evans/create-or-update-comment` action for posting a comment in java dependency review workflow 

Original action does not support comment body input from file, which is crusual on huge comments, such as OpenSSF report. If using text input, the `Argument list too long` error occurs.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
