### PR TITLE
feat: pin runner tag to ubuntu-24.04 with ability to change via workflow input

### DIFF
--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -54,7 +54,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -51,6 +51,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -65,9 +70,10 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   docker_build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -54,7 +54,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -51,6 +51,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -65,9 +70,10 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   calculate_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       next-version: ${{ steps.semantic_versioning.outputs.next-version }}
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
@@ -77,7 +83,7 @@ jobs:
         id: semantic_versioning
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -79,7 +79,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.1.0
         id: semantic_versioning
 
   release:
@@ -100,14 +100,14 @@ jobs:
           remove-dotnet: "true"
           remove-haskell: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.1.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.1.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -30,7 +30,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 jobs:

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -27,11 +27,16 @@ on:
         type: string
         default: "latest"
         description: ORT version to use
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 jobs:
   style_checks:
     if: ${{ inputs.style-checks-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -45,7 +50,7 @@ jobs:
 
   ort:
     if: ${{ inputs.ort-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.1.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -67,6 +67,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -85,9 +90,10 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       java-version: ${{ inputs.java-version }}
       java-distribution: ${{ inputs.java-distribution }}
+      runs-on: ${{ inputs.runs-on }}
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -102,7 +108,7 @@ jobs:
           GPR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
   docker_build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.1.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -70,7 +70,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -67,6 +67,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -85,9 +90,10 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       java-version: ${{ inputs.java-version }}
       java-distribution: ${{ inputs.java-distribution }}
+      runs-on: ${{ inputs.runs-on }}
 
   calculate_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       next-version: ${{ steps.semantic_versioning.outputs.next-version }}
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
@@ -97,7 +103,7 @@ jobs:
         id: semantic_versioning
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -99,7 +99,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.1.0
         id: semantic_versioning
 
   release:
@@ -120,14 +120,14 @@ jobs:
           remove-dotnet: "true"
           remove-haskell: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.1.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.1.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -135,7 +135,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: gradle/actions/dependency-submission@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.1.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -70,7 +70,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.1.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.1.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -46,7 +46,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 jobs:

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -43,11 +43,16 @@ on:
         type: string
         default: "temurin"
         description: Java distribution to use
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 jobs:
   style_checks:
     if: ${{ inputs.style-checks-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -67,7 +72,7 @@ jobs:
 
   code_checks:
     if: ${{ inputs.code-checks-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -87,7 +92,7 @@ jobs:
 
   ort:
     if: ${{ inputs.ort-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -74,7 +74,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -71,6 +71,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -90,9 +95,10 @@ jobs:
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
       node-version: ${{ inputs.node-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   docker_build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -75,6 +75,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -94,9 +99,10 @@ jobs:
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
       node-version: ${{ inputs.node-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   calculate_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       next-version: ${{ steps.semantic_versioning.outputs.next-version }}
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
@@ -106,7 +112,7 @@ jobs:
         id: semantic_versioning
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -108,7 +108,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.1.0
         id: semantic_versioning
 
   release:
@@ -129,14 +129,14 @@ jobs:
           remove-dotnet: "true"
           remove-haskell: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.1.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.1.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -145,7 +145,7 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -188,7 +188,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.1.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -78,7 +78,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.1.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.1.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.1.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -47,11 +47,16 @@ on:
         type: string
         default: "22"
         description: NodeJS version to use
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 jobs:
   format_checks:
     if: ${{ inputs.format-checks-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -68,7 +73,7 @@ jobs:
 
   style_checks:
     if: ${{ inputs.style-checks-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -85,7 +90,7 @@ jobs:
 
   code_checks:
     if: ${{ inputs.code-checks-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -102,7 +107,7 @@ jobs:
 
   ort:
     if: ${{ inputs.ort-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -50,7 +50,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 jobs:

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -67,6 +67,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -85,9 +90,10 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       python-version: ${{ inputs.python-version }}
       poetry-version: ${{ inputs.poetry-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   docker_build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -70,7 +70,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -100,7 +100,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.1.0
         id: semantic_versioning
 
   release:
@@ -121,7 +121,7 @@ jobs:
           remove-dotnet: "true"
           remove-haskell: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.1.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -132,7 +132,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@2.0.1
+      - uses: epam/ai-dial-ci/actions/build_docker@2.1.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -152,7 +152,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.1.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -70,7 +70,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -67,6 +67,11 @@ on:
         type: boolean
         default: false
         description: Maximize build space by removing unwanted software
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -85,9 +90,10 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       python-version: ${{ inputs.python-version }}
       poetry-version: ${{ inputs.poetry-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   calculate_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       next-version: ${{ steps.semantic_versioning.outputs.next-version }}
       next-version-without-hyphens: ${{ steps.semantic_versioning.outputs.next-version-without-hyphens }}
@@ -98,7 +104,7 @@ jobs:
         id: semantic_versioning
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.1.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.1.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -43,11 +43,16 @@ on:
         type: string
         description: "Poetry version to use"
         default: "latest"
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 jobs:
   style_checks:
     if: ${{ inputs.style-checks-enabled }}
-    runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -64,7 +69,7 @@ jobs:
 
   code_checks:
     if: ${{ inputs.code-checks-enabled }}
-    runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -81,7 +86,7 @@ jobs:
 
   ort:
     if: ${{ inputs.ort-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -46,7 +46,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 jobs:

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -67,6 +67,11 @@ on:
         type: string
         description: "Poetry version to use"
         default: "1.8.5"
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -90,9 +95,10 @@ jobs:
       trivy-severity-for-sarif: ${{ inputs.trivy-severity-for-sarif }}
       trivy-limit-severities-for-sarif: ${{ inputs.trivy-limit-severities-for-sarif }}
       python-version: ${{ inputs.python-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   build:
-    runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -70,7 +70,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 env:

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.1.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -100,7 +100,7 @@ jobs:
       next-version-without-hyphens: ${{ steps.semantic_versioning.outputs.next-version-without-hyphens }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.0.1
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.1.0
         id: semantic_versioning
 
   release:
@@ -113,14 +113,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.0.1
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.1.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.1.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -135,7 +135,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.0.1
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.1.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version-without-hyphens }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -70,7 +70,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 jobs:

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -67,6 +67,11 @@ on:
         type: string
         description: "Poetry version to use"
         default: "1.8.5"
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 jobs:
   test:
@@ -87,9 +92,10 @@ jobs:
       trivy-severity-for-sarif: ${{ inputs.trivy-severity-for-sarif }}
       trivy-limit-severities-for-sarif: ${{ inputs.trivy-limit-severities-for-sarif }}
       python-version: ${{ inputs.python-version }}
+      runs-on: ${{ inputs.runs-on }}
 
   calculate_version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       next-version-without-hyphens: ${{ steps.semantic_versioning.outputs.next-version-without-hyphens }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
@@ -98,7 +104,7 @@ jobs:
         id: semantic_versioning
 
   release:
-    runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -78,7 +78,7 @@ on:
       runs-on:
         type: string
         description: "Overrides jobs runs-on settings (json-encoded list)"
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-24.04"]'
         required: false
 
 jobs:

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -75,11 +75,16 @@ on:
         type: string
         description: "Poetry version to use"
         default: "latest"
+      runs-on:
+        type: string
+        description: "Overrides jobs runs-on settings (json-encoded list)"
+        default: '["ubuntu-latest"]'
+        required: false
 
 jobs:
   style_checks:
     if: ${{ inputs.style-checks-enabled }}
-    runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -96,7 +101,7 @@ jobs:
 
   code_checks:
     if: ${{ inputs.code-checks-enabled }}
-    runs-on: ubuntu-22.04 # TODO: ubuntu-latest have python 3.12 by default and breaks `pip install` system-wide packages
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +125,7 @@ jobs:
 
   ort:
     if: ${{ inputs.ort-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -137,7 +142,7 @@ jobs:
 
   trivy:
     if: ${{ inputs.trivy-enabled }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Run Trivy vulnerability scanner (SARIF, no fail)
         id: trivy-sarif

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -118,9 +118,21 @@ jobs:
         continue-on-error: ${{ inputs.bypass-checks || inputs.code-checks-bypassed }}
         shell: bash
         run: |
-          pip install twine==5.0.0
+          # Workflow explanation:
+          # 1. Use venv from python_prepare action and build the package(s)
+          # 2. Create a separate venv for twine, install and check the package(s)
+          # 3. Switch back to the original venv and run tests
+          source $VENV
           make build
+          deactivate
+
+          python -m venv .venv-twine
+          source .venv-twine/bin/activate
+          pip install "twine~=6.0"
           twine check dist/*
+          deactivate
+
+          source $VENV
           make test PYTHON=${{ matrix.python-version }}
 
   ort:

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.1.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.0.1
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.1.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Add a feature to make `runs-on` overridable through input for most workflows. The default value - `ubuntu-24.04` 
- Fix the Python package code_checks issue when Twine is installed system-wide and its dependencies conflict with app dependencies, by creating a separate venv.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
