### PR TITLE
fix: set 1 hour as timeout for E2E tests

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -139,7 +139,7 @@ jobs:
   e2e-status:
     runs-on: ubuntu-latest
     needs: e2e-test
-    if: success() || failure()
+    if: always()
     steps:
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:

--- a/.github/workflows/gh-e2e-test.yml
+++ b/.github/workflows/gh-e2e-test.yml
@@ -43,6 +43,10 @@ on:
         description: "E2E tests Git branch"
         type: string
         default: "development"
+      timeout-minutes:
+        description: "The maximum number of minutes to let a job run before GitHub automatically cancels it."
+        type: number
+        default: 60
     outputs:
       chat-status:
         description: "Status of Chat E2E test"
@@ -71,6 +75,7 @@ on:
 jobs:
   chat:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
       status: ${{ steps.e2e-test-chat.outcome }}
       job-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -152,6 +157,7 @@ jobs:
           retention-days: 30
   overlay:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
       status: ${{ steps.e2e-test-overlay.outcome }}
       job-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #245 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Configure 1 hour as timeout for `e2e-test/chat` and `e2e-test/overlay` jobs.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
