### PR TITLE
fix: prevent environment destroy if e2e-test was cancelled

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -55,7 +55,7 @@ jobs:
     needs:
       - deploy-env
       - e2e-test
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Destroy environment
         id: destroy


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

- prevent environment destroy if e2e-test was cancelled

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
