### PR TITLE
fix: add workflow run link in the beginning (closes #243)

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -6,6 +6,15 @@ jobs:
   deploy-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Workflow run URL
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            >GitHub actions run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
       - name: Check repository owner
         id: owner
         run: |
@@ -23,6 +32,7 @@ jobs:
             exit 1
           fi
           echo "All checks passed."
+
       - name: Checks and transformations
         id: vars
         run: |


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #243 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Add link to workflow run in the beginning of `/deploy-review` command comment.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
