### PR TITLE
chore(doc): promote trigger hack for Deploy development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,14 +392,19 @@ A common case is to trigger development environment(s) update from GitHub to Git
 name: Deploy development
 
 on:
-  workflow_dispatch:
-  registry_package:
+  workflow_dispatch: # manual run
+  registry_package: # on new package version (main path)
+  workflow_run: # HACK: redundant trigger to mitigate GitHub's huge delays in registry_package event processing
+    workflows: ["Release Workflow"]
+    types:
+      - completed
 
 jobs:
   gitlab-dev-deploy:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event.registry_package.package_version.container_metadata.tag.name == 'development'
+      github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
     uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@main
     with:
       gitlab-project-id: "1487"
@@ -417,14 +422,19 @@ In case of multiple environments, continue creating multiple GitHub environments
 name: Deploy development
 
 on:
-  workflow_dispatch:
-  registry_package:
+  workflow_dispatch: # manual run
+  registry_package: # on new package version (main path)
+  workflow_run: # HACK: redundant trigger to mitigate GitHub's huge delays in registry_package event processing
+    workflows: ["Release Workflow"]
+    types:
+      - completed
 
 jobs:
   trigger:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event.registry_package.package_version.container_metadata.tag.name == 'development'
+      github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

GitHub is experiencing significant delays (hours, sometimes days) in processing the `registry_package` event. Adding a hack with a redundant `workflow_run` trigger, which does not **guarantee** updating the deploy on a new version, but mitigates the issue with very high probability.

The race condition, if both triggers happen, is resolved by the `concurrency` rule embedded in `.github/workflows/deploy-development.yml`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
