### PR TITLE
feat: allow independent choice of output artifacts for node workflows

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -134,7 +134,7 @@ jobs:
           fi
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.5.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.6.0
     if: ${{ !(contains(github.event.client_payload.github.payload.issue.labels.*.name, 'skip-e2e') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'skip-e2e')) }}
     needs:
       - deploy-review

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,7 +38,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.5.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.6.0
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -84,7 +84,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.6.0
         id: semantic_versioning
 
   release:
@@ -108,14 +108,14 @@ jobs:
           remove-docker-images: "true"
           remove-cached-tools: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -136,7 +136,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.6.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -104,7 +104,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.6.0
         id: semantic_versioning
 
   release:
@@ -128,14 +128,14 @@ jobs:
           remove-docker-images: "true"
           remove-cached-tools: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -143,7 +143,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -167,7 +167,7 @@ jobs:
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
       - uses: gradle/actions/dependency-submission@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.6.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -132,7 +132,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+        uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -43,6 +43,10 @@ on:
         type: string
         default: "latest"
         description: ORT version to use
+      docker-build-enabled:
+        type: boolean
+        default: true
+        description: "Enable Docker build"
       trivy-enabled:
         type: boolean
         default: true
@@ -81,6 +85,10 @@ on:
         description: "Docker build platforms (default linux/amd64)"
         default: "linux/amd64"
         required: false
+      dockerfile-path:
+        type: string
+        default: "Dockerfile"
+        description: "Path to the Dockerfile (default: ./Dockerfile)"
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -103,6 +111,7 @@ jobs:
       runs-on: ${{ inputs.runs-on }}
 
   docker_build:
+    if: ${{ inputs.docker-build-enabled }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Maximize build space
@@ -116,10 +125,14 @@ jobs:
           remove-docker-images: "true"
           remove-cached-tools: "true"
           remove-large-packages: "true"
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
+      - if: ${{ hashFiles(inputs.dockerfile-path) != '' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
+      - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
+        uses: epam/ai-dial-ci/actions/build_docker@2.5.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test
@@ -129,3 +142,4 @@ jobs:
           trivy-severity-for-sarif: ${{ inputs.trivy-severity-for-sarif }}
           trivy-limit-severities-for-sarif: ${{ inputs.trivy-limit-severities-for-sarif }}
           platforms: ${{ inputs.platforms }}
+          dockerfile-path: ${{ inputs.dockerfile-path }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -43,6 +43,10 @@ on:
         type: string
         default: "latest"
         description: ORT version to use
+      docker-build-enabled:
+        type: boolean
+        default: true
+        description: "Enable Docker build"
       trivy-enabled:
         type: boolean
         default: true
@@ -85,6 +89,10 @@ on:
         description: "Docker build platforms (default linux/amd64)"
         default: "linux/amd64"
         required: false
+      dockerfile-path:
+        type: string
+        default: "Dockerfile"
+        description: "Path to the Dockerfile (default: ./Dockerfile)"
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -153,7 +161,9 @@ jobs:
         shell: bash
         run: |
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version || true # upstream branch may already be updated
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
+      - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
+        uses: epam/ai-dial-ci/actions/build_docker@2.5.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -168,6 +178,7 @@ jobs:
           trivy-severity-for-sarif: ${{ inputs.trivy-severity-for-sarif }}
           trivy-limit-severities-for-sarif: ${{ inputs.trivy-limit-severities-for-sarif }}
           platforms: ${{ inputs.platforms }}
+          dockerfile-path: ${{ inputs.dockerfile-path }}
           image-extra-aliases: |
             ${{ env.IMAGE_NAME }}:${{ needs.calculate_version.outputs.next-version }}
             ${{ github.ref == 'refs/heads/development' && format('{0}:{1}', env.IMAGE_NAME, 'development') || ''}}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -121,7 +121,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.6.0
         id: semantic_versioning
 
   release:
@@ -145,14 +145,14 @@ jobs:
           remove-docker-images: "true"
           remove-cached-tools: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -163,7 +163,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version || true # upstream branch may already be updated
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+        uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -208,7 +208,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.6.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -105,7 +105,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.6.0
         id: semantic_versioning
 
   release:
@@ -129,7 +129,7 @@ jobs:
           remove-docker-images: "true"
           remove-cached-tools: "true"
           remove-large-packages: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -140,7 +140,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@2.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@2.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.6.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -100,7 +100,7 @@ jobs:
       next-version-without-hyphens: ${{ steps.semantic_versioning.outputs.next-version-without-hyphens }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.6.0
         id: semantic_versioning
 
   release:
@@ -113,14 +113,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -135,7 +135,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.6.0
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version-without-hyphens }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.6.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/README.md
+++ b/README.md
@@ -3,22 +3,27 @@
 - [AI DIAL workflows](#ai-dial-workflows)
   - [Overview](#overview)
   - [Usage](#usage)
-    - [PR Workflow (NodeJS (npm), Docker)](#pr-workflow-nodejs-npm-docker)
-    - [Release Workflow (NodeJS (npm), Docker)](#release-workflow-nodejs-npm-docker)
-    - [PR Workflow (Java (gradle), Docker)](#pr-workflow-java-gradle-docker)
-    - [Release Workflow (Java (gradle), Docker)](#release-workflow-java-gradle-docker)
-    - [PR Workflow (Python (poetry), Docker)](#pr-workflow-python-poetry-docker)
-    - [Release Workflow (Python (poetry), Docker)](#release-workflow-python-poetry-docker)
-    - [PR Workflow (Python (poetry), package)](#pr-workflow-python-poetry-package)
-    - [Release Workflow (Python (poetry), package)](#release-workflow-python-poetry-package)
-    - [PR Workflow (Generic, Docker)](#pr-workflow-generic-docker)
-    - [Release Workflow (Generic, Docker)](#release-workflow-generic-docker)
-    - [Validate PR title](#validate-pr-title)
-    - [Deploy review environment](#deploy-review-environment)
-    - [Cleanup for untagged images in GHCR](#cleanup-for-untagged-images-in-ghcr)
-    - [Dependency Review (Java (gradle))](#dependency-review-java-gradle)
-    - [Trigger deployment of development environment in GitLab](#trigger-deployment-of-development-environment-in-gitlab)
-    - [Trivy additional configuration](#trivy-additional-configuration)
+    - [NodeJS (npm)](#nodejs-npm)
+      - [PR Workflow](#pr-workflow)
+      - [Release Workflow](#release-workflow)
+    - [Java (gradle)](#java-gradle)
+      - [PR Workflow (Docker)](#pr-workflow-docker)
+      - [Release Workflow (Docker)](#release-workflow-docker)
+      - [Dependency Review](#dependency-review)
+    - [Python (poetry)](#python-poetry)
+      - [PR Workflow (Docker)](#pr-workflow-docker-1)
+      - [Release Workflow (Docker)](#release-workflow-docker-1)
+      - [PR Workflow (package)](#pr-workflow-package)
+      - [Release Workflow (package)](#release-workflow-package)
+    - [Generic Docker](#generic-docker)
+      - [PR Workflow](#pr-workflow-1)
+      - [Release Workflow](#release-workflow-1)
+    - [Others](#others)
+      - [Validate PR title](#validate-pr-title)
+      - [Deploy review environment](#deploy-review-environment)
+      - [Cleanup for untagged images in GHCR](#cleanup-for-untagged-images-in-ghcr)
+      - [Trigger deployment of development environment in GitLab](#trigger-deployment-of-development-environment-in-gitlab)
+      - [Trivy additional configuration](#trivy-additional-configuration)
   - [Contributing](#contributing)
 
 ## Overview
@@ -31,7 +36,9 @@ Contains reusable workflows for AI-DIAL group of repositories under EPAM GitHub 
 
 These workflows could be imported to any repository under EPAM GitHub organization as standard `.github/workflows` files. See examples below (replace `@main` with specific version tag).
 
-### PR Workflow (NodeJS (npm), Docker)
+### NodeJS (npm)
+
+#### PR Workflow
 
 `pr.yml`
 
@@ -54,7 +61,7 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### Release Workflow (NodeJS (npm), Docker)
+#### Release Workflow
 
 `release.yml`
 
@@ -77,7 +84,9 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### PR Workflow (Java (gradle), Docker)
+### Java (gradle)
+
+#### PR Workflow (Docker)
 
 `pr.yml`
 
@@ -100,7 +109,7 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### Release Workflow (Java (gradle), Docker)
+#### Release Workflow (Docker)
 
 `release.yml`
 
@@ -123,7 +132,35 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### PR Workflow (Python (poetry), Docker)
+#### Dependency Review
+
+To support Dependabot security updates, GitHub requires uploading dependency graph data to GitHub's Dependency Graph API. To enable this feature, add the workflow from example below to your repository. You'll start getting review comments on PRs.
+
+`dependency-review.yml`
+
+```yml
+name: Dependency Review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    uses: epam/ai-dial-ci/.github/workflows/java_dependency_review.yml@main
+    secrets:
+      ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
+```
+
+### Python (poetry)
+
+#### PR Workflow (Docker)
 
 `pr.yml`
 
@@ -146,7 +183,7 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### Release Workflow (Python (poetry), Docker)
+#### Release Workflow (Docker)
 
 `release.yml`
 
@@ -169,7 +206,7 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### PR Workflow (Python (poetry), package)
+#### PR Workflow (package)
 
 `pr.yml`
 
@@ -190,7 +227,7 @@ jobs:
     secrets: inherit
 ```
 
-### Release Workflow (Python (poetry), package)
+#### Release Workflow (package)
 
 `release.yml`
 
@@ -211,7 +248,9 @@ jobs:
     secrets: inherit
 ```
 
-### PR Workflow (Generic, Docker)
+### Generic Docker
+
+#### PR Workflow
 
 `pr.yml`
 
@@ -234,7 +273,7 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### Release Workflow (Generic, Docker)
+#### Release Workflow
 
 `release.yml`
 
@@ -257,7 +296,9 @@ jobs:
     #   platforms: "linux/amd64,linux/arm64"
 ```
 
-### Validate PR title
+### Others
+
+#### Validate PR title
 
 `pr-title-check.yml`
 
@@ -282,7 +323,7 @@ jobs:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
 ```
 
-### Deploy review environment
+#### Deploy review environment
 
 `slash-command-dispatch.yml`
 
@@ -319,16 +360,18 @@ jobs:
 If you need to disable E2E tests execution:
 
 - for the **whole repository**: add `skip-e2e` argument to `static_args` list
+
   ```yml
                 "static_args": [
                   "application=${{ github.event.repository.name }}",
                   "skip-e2e"
                 ]
   ```
+
 - for the **specific PR**: assign `skip-e2e` label to PR
 - **once**: use `/deploy-review skip-e2e` command in PR comment
 
-### Cleanup for untagged images in GHCR
+#### Cleanup for untagged images in GHCR
 
 `cleanup-untagged-images.yml`
 
@@ -351,33 +394,7 @@ jobs:
           delete-untagged: true
 ```
 
-### Dependency Review (Java (gradle))
-
-To support Dependabot security updates, GitHub requires uploading dependency graph data to GitHub's Dependency Graph API. To enable this feature, add the workflow from example below to your repository. You'll start getting review comments on PRs.
-
-`dependency-review.yml`
-
-```yml
-name: Dependency Review
-
-on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
-jobs:
-  dependency-review:
-    uses: epam/ai-dial-ci/.github/workflows/java_dependency_review.yml@main
-    secrets:
-      ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
-```
-
-### Trigger deployment of development environment in GitLab
+#### Trigger deployment of development environment in GitLab
 
 A common case is to trigger development environment(s) update from GitHub to GitLab, e.g. each time a `development` branch produces a new artifact. Also, it could be not single, but several environments, representing different configuration presets of a single app. To use the example below:
 
@@ -459,7 +476,7 @@ jobs:
       DEPLOY_TRIGGER_TOKEN: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
 ```
 
-### Trivy additional configuration
+#### Trivy additional configuration
 
 To change predefined Trivy parameters or set up additional configuration options, create `trivy.yaml` file in root of your repository. Use example below to add fallback repositories for vulnerabilities and checks DB and thus mitigate rate limit issues.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ These workflows could be imported to any repository under EPAM GitHub organizati
 
 ### NodeJS (npm)
 
+> [!tip]
+> Workflows allow independent choices of output artifacts: container image, npm package, or both (default) via `docker-build-enabled` and `publish-enabled` inputs respectively. Set variables values to match your needs.
+
 #### PR Workflow
 
 `pr.yml`
@@ -57,8 +60,6 @@ jobs:
   run_tests:
     uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 #### Release Workflow
@@ -80,8 +81,6 @@ jobs:
   release:
     uses: epam/ai-dial-ci/.github/workflows/node_release.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 ### Java (gradle)
@@ -105,8 +104,6 @@ jobs:
   run_tests:
     uses: epam/ai-dial-ci/.github/workflows/java_pr.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 #### Release Workflow (Docker)
@@ -128,8 +125,6 @@ jobs:
   release:
     uses: epam/ai-dial-ci/.github/workflows/java_release.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 #### Dependency Review
@@ -179,8 +174,6 @@ jobs:
   run_tests:
     uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 #### Release Workflow (Docker)
@@ -202,8 +195,6 @@ jobs:
   release:
     uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 #### PR Workflow (package)
@@ -269,8 +260,6 @@ jobs:
   run_tests:
     uses: epam/ai-dial-ci/.github/workflows/generic_docker_pr.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 #### Release Workflow
@@ -292,8 +281,6 @@ jobs:
   release:
     uses: epam/ai-dial-ci/.github/workflows/generic_docker_release.yml@main
     secrets: inherit
-    # with:
-    #   platforms: "linux/amd64,linux/arm64"
 ```
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These workflows could be imported to any repository under EPAM GitHub organizati
 ### NodeJS (npm)
 
 > [!tip]
-> Workflows allow independent choices of output artifacts: container image, npm package, or both (default) via `docker-build-enabled` and `publish-enabled` inputs respectively. Set variables values to match your needs.
+> Workflows allow independent choices of output artifacts: container image, npm package, or both (default) via `docker-build-enabled` and `publish-enabled` inputs respectively. Set variable values to match your needs.
 
 #### PR Workflow
 

--- a/actions/build_docker/action.yml
+++ b/actions/build_docker/action.yml
@@ -70,6 +70,10 @@ inputs:
     required: false
     description: "Docker build platforms (default linux/amd64)"
     default: "linux/amd64"
+  dockerfile-path:
+    required: false
+    description: "Path to the Dockerfile (default: ./Dockerfile)"
+    default: "Dockerfile"
 
 runs:
   using: "composite"
@@ -96,6 +100,7 @@ runs:
       uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
       with:
         context: .
+        file: ${{ inputs.dockerfile-path }}
         load: true
         platforms: linux/amd64
         cache-from: type=gha
@@ -167,6 +172,7 @@ runs:
       uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
       with:
         context: .
+        file: ${{ inputs.dockerfile-path }}
         push: true
         platforms: ${{ inputs.platforms }}
         cache-from: type=gha


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Add ability for independent choice of output artifacts: container image, npm package, or both (default) via `docker-build-enabled` and `publish-enabled` inputs, respectively, for node workflows. Set variable values to match your needs.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
