### PR TITLE
fix: output report generation for java dependency review

### DIFF
--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -67,8 +67,11 @@ jobs:
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 600
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
+        name: Save dependency review output report
         run: |
-          echo "${{ steps.dependency-review.outputs.comment-content }}" > openssf-report.html
+          cat << 'EOF' > openssf-report.html
+          ${{ steps.dependency-review.outputs.comment-content }}
+          EOF
       - if: ${{ steps.dependency-review.outputs.comment-content != null }}
         # Use separate action to comment because the original one can't do it without PR context
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
While dealing with random content, we can face with unescaped sequence that will break our current output-to-file approach, e.g.
<img width="848" height="122" alt="image" src="https://github.com/user-attachments/assets/1dd91181-ee7d-4e4a-8ab3-55ac55d64f50" />

To fix this, I suggest trying heredoc approach.

We must remember that GitHub's [limit on step outputs is 1MB](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#outputs-for-docker-container-and-javascript-actions), but for environment variables, it's 64KB, so using intermediate environment variables isn't really an option.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
