### PR TITLE
fix: use own runner cleanup action

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -134,7 +134,7 @@ jobs:
           fi
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.7.2
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.7.3
     if: ${{ !(contains(github.event.client_payload.github.payload.issue.labels.*.name, 'skip-e2e') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'skip-e2e')) }}
     needs:
       - deploy-review

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,7 +38,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.7.2
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@2.7.3
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+      - uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -84,7 +84,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.3
         id: semantic_versioning
 
   release:
@@ -123,14 +123,14 @@ jobs:
           remove-go: "true"
           remove-ruby: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.3
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+      - uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.3
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_dependency_review.yml
+++ b/.github/workflows/java_dependency_review.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+      - uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -122,7 +122,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.3
         id: semantic_versioning
 
   release:
@@ -161,14 +161,14 @@ jobs:
           remove-go: "true"
           remove-ruby: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.3
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+      - uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -199,7 +199,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.3
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/java_prepare@2.7.3
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -145,7 +145,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+        uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -121,7 +121,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.3
         id: semantic_versioning
 
   release:
@@ -160,14 +160,14 @@ jobs:
           remove-go: "true"
           remove-ruby: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.3
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.3
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -178,7 +178,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version || true # upstream branch may already be updated
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+        uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -223,7 +223,7 @@ jobs:
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           IS_DEVELOPMENT_BRANCH: ${{ github.ref == 'refs/heads/development' }}
           IS_RELEASE_BRANCH: ${{ startsWith(github.ref, 'refs/heads/release-') }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.3
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.3
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.3
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/node_prepare@2.7.3
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+      - uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -105,7 +105,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.3
         id: semantic_versioning
 
   release:
@@ -144,7 +144,7 @@ jobs:
           remove-go: "true"
           remove-ruby: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.3
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -155,7 +155,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@2.7.2
+      - uses: epam/ai-dial-ci/actions/build_docker@2.7.3
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
             ${{ github.ref == 'refs/heads/development' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'development') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || ''}}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || ''}}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.3
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.3
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.3
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.3
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -100,7 +100,7 @@ jobs:
       next-version-without-hyphens: ${{ steps.semantic_versioning.outputs.next-version-without-hyphens }}
       latest-tag: ${{ steps.semantic_versioning.outputs.latest-tag }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.2
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@2.7.3
         id: semantic_versioning
 
   release:
@@ -113,14 +113,14 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.2
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@2.7.3
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-tag }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.3
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -135,7 +135,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.2
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@2.7.3
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version-without-hyphens }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.3
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.2
+      - uses: epam/ai-dial-ci/actions/python_prepare@2.7.3
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes `no space left on device` issue when building extra-large (~9 GB) container images and scanning them with Trivy.

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Replaced 3rd-party runner cleanup action with our own fork, which gives approx +10 GB, works faster, and provides more features.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
