### PR TITLE
fix: add logic to perform Java style checks only once per run

### DIFF
--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -99,16 +99,16 @@ jobs:
           STYLE_TASK_NAME: ${{ inputs.style-task-name }}
         run: |
           #!/bin/bash
-          CHECK_ARGS=()
+          check_args=()
 
           if [ "$SKIP_STYLE_TASK" = "true" ]; then
             if [ -n "$STYLE_TASK_NAME" ] && ./gradlew tasks --all --quiet | grep -qw "$STYLE_TASK_NAME"; then
-              CHECK_ARGS=(-x "$STYLE_TASK_NAME")
+              check_args=(-x "$STYLE_TASK_NAME")
             else
               echo "::warning::Gradle task '$STYLE_TASK_NAME' was not found; nothing to exclude"
             fi
           fi
-          ./gradlew check "${CHECK_ARGS[@]}" || { echo "::error::Checks failed" && exit 1; } # TODO: figure out why we need to capture exit code
+          ./gradlew check "${check_args[@]}" || { echo "::error::Checks failed" && exit 1; } # TODO: figure out why we need to capture exit code
 
   ort:
     if: ${{ inputs.ort-enabled }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: false
         description: Do not fail pipeline if style_checks failed
+      style-task-name:
+        type: string
+        default: "checkstyleMain"
+        description: Gradle task name to run in style_checks
       code-checks-enabled:
         type: boolean
         default: true
@@ -66,8 +70,13 @@ jobs:
         env:
           GPR_USERNAME: ${{ github.actor }}
           GPR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          STYLE_TASK_NAME: ${{ inputs.style-task-name }}
         run: |
-          ./gradlew checkstyleMain
+          if [ -n "$STYLE_TASK_NAME" ] && ./gradlew tasks --all --quiet | grep -qw "$STYLE_TASK_NAME"; then
+            ./gradlew "$STYLE_TASK_NAME"
+          else
+            echo "::error::Gradle task '$STYLE_TASK_NAME' was not found" && exit 1
+          fi
 
   code_checks:
     if: ${{ inputs.code-checks-enabled }}
@@ -86,8 +95,20 @@ jobs:
         env:
           GPR_USERNAME: ${{ github.actor }}
           GPR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_STYLE_TASK: ${{ inputs.style-checks-enabled }}
+          STYLE_TASK_NAME: ${{ inputs.style-task-name }}
         run: |
-          ./gradlew check || { echo "::error::Tests failed" && exit 1; } # TODO: figure out why we need to capture exit code
+          #!/bin/bash
+          CHECK_ARGS=()
+
+          if [ "$SKIP_STYLE_TASK" = "true" ]; then
+            if [ -n "$STYLE_TASK_NAME" ] && ./gradlew tasks --all --quiet | grep -qw "$STYLE_TASK_NAME"; then
+              CHECK_ARGS=(-x "$STYLE_TASK_NAME")
+            else
+              echo "::warning::Gradle task '$STYLE_TASK_NAME' was not found; nothing to exclude"
+            fi
+          fi
+          ./gradlew check "${CHECK_ARGS[@]}" || { echo "::error::Checks failed" && exit 1; } # TODO: figure out why we need to capture exit code
 
   ort:
     if: ${{ inputs.ort-enabled }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #466 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Conditionally skip Gradle style task while executing `check` Gradle lifecycle task
- Make style check Gradle task name configurable (bonus feature, not requested so scoped to java_test.yml workflow for now)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
