### PR TITLE
fix: show GitLab host and pipeline URL in logs

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -39,3 +39,4 @@ jobs:
           access_token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
           id: ${{ inputs.gitlab-project-id }}
           ref: ${{ inputs.gitlab-project-ref }}
+          verbose: true

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -40,3 +40,4 @@ jobs:
           id: ${{ inputs.gitlab-project-id }}
           ref: ${{ inputs.gitlab-project-ref }}
           verbose: true
+          download_artifacts_on_failure: false

--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -132,6 +132,7 @@ jobs:
           access_token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
           id: ${{ vars.DEPLOY_PROJECT_ID }}
           ref: ${{ vars.DEPLOY_REF }}
+          download_artifacts_on_failure: false
           verbose: true
           variables: >
             {

--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -19,12 +19,12 @@
 # Recommended secrets and variables layout:
 # - Repository:
 #   - Variables:
+#     - DEPLOY_HOST:                          GitLab instance hostname (e.g. gitlab.com)
 #     - REVIEW_BASE_DOMAIN:                   Base domain for review environments (e.g. example.com)
 #     - (optional) DISPATCH_WHITELIST:        JSON array of repository names (wildcard supported) allowed to dispatch slash command events
 #                                             Default: ["ai-dial*"]
 #   - Secrets:
 #     - ACTIONS_BOT_TOKEN:                    GitHub token with permissions to create/update comments
-#     - DEPLOY_HOST:                          GitLab instance hostname (e.g. gitlab.com)
 #     - E2E_ADMIN:                            A name of an application user with admin privileges
 #     - E2E_OVERLAY_USERNAME:                 Name(s) of application user(s) for ai-dial-chat (overlay) tests
 #     - E2E_USERNAME:                         Name(s) of application user(s) for ai-dial-chat tests
@@ -127,11 +127,12 @@ jobs:
         id: deploy
         uses: digital-blueprint/gitlab-pipeline-trigger-action@c59b56e9d2688ab42c1304322ac8831a4ef6f7d2 # v1.4.0
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
+          host: ${{ vars.DEPLOY_HOST }}
           trigger_token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
           access_token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
           id: ${{ vars.DEPLOY_PROJECT_ID }}
           ref: ${{ vars.DEPLOY_REF }}
+          verbose: true
           variables: >
             {
               "APPLICATION_NAME":"${{ github.event.client_payload.slash_command.args.named.application }}",

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,6 +30,8 @@ jobs:
           access_token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
           id: ${{ github.event.client_payload.gitlab-project-id }}
           ref: ${{ github.event.client_payload.gitlab-project-ref || vars.DEPLOY_REF }}
+          download_artifacts_on_failure: false
+          verbose: true
           variables: >
             {
               "TRIGGER_GITHUB_APP":"${{ github.event.client_payload.github-app }}",
@@ -71,6 +73,7 @@ jobs:
           access_token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
           id: ${{ github.event.client_payload.gitlab-project-id }}
           ref: ${{ github.event.client_payload.gitlab-project-ref || vars.DEPLOY_REF }}
+          download_artifacts_on_failure: false
           verbose: true
           variables: >
             {

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -25,7 +25,7 @@ jobs:
         id: deploy
         uses: digital-blueprint/gitlab-pipeline-trigger-action@c59b56e9d2688ab42c1304322ac8831a4ef6f7d2 # v1.4.0
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
+          host: ${{ vars.DEPLOY_HOST }}
           trigger_token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
           access_token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
           id: ${{ github.event.client_payload.gitlab-project-id }}
@@ -66,11 +66,12 @@ jobs:
         id: destroy
         uses: digital-blueprint/gitlab-pipeline-trigger-action@c59b56e9d2688ab42c1304322ac8831a4ef6f7d2 # v1.4.0
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
+          host: ${{ vars.DEPLOY_HOST }}
           trigger_token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
           access_token: ${{ secrets.DEPLOY_ACCESS_TOKEN }}
           id: ${{ github.event.client_payload.gitlab-project-id }}
           ref: ${{ github.event.client_payload.gitlab-project-ref || vars.DEPLOY_REF }}
+          verbose: true
           variables: >
             {
               "TRIGGER_GITHUB_APP":"${{ needs.deploy-env.outputs.github-app }}",


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Show GitLab host and pipeline URL in logs. The host is not a sensitive information. Pipeline URL _may theoretically_ be treated as such, but we get more profit from RD team observability, than from hiding it
- Ensure we never try to download anything from GitLab to GitHub

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
