### PR TITLE
hotfix: pin ORT scanner version

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,7 +38,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.0.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.0.1
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -26,7 +26,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -30,7 +30,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -87,7 +87,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -127,7 +127,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -135,7 +135,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -33,7 +33,7 @@ on:
         description: Do not fail pipeline if ORT scan failed
       ort-version:
         type: string
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
         description: ORT version to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -128,7 +128,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -169,7 +169,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -177,7 +177,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -185,7 +185,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -206,7 +206,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -37,7 +37,7 @@ on:
         description: Do not fail pipeline if ORT scan failed
       ort-version:
         type: string
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
         description: ORT version to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.0.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -143,7 +143,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -42,7 +42,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -127,7 +127,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -167,7 +167,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -175,7 +175,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -186,7 +186,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -249,7 +249,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -46,7 +46,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.0.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -34,7 +34,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -38,7 +38,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -109,7 +109,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -149,7 +149,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -161,7 +161,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.0.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.0.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -180,7 +180,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -38,7 +38,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -42,7 +42,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -106,7 +106,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.0.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -120,7 +120,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.0.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -128,7 +128,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -143,7 +143,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.0.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.0.1
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}


### PR DESCRIPTION
pin ORT version to `85.0.0` due to java.util.NoSuchElementException in `85.1.0`

```log
/        \_______   \__    ___/ The OSS Review Toolkit, version 85.1.0,                  
|    |   | |       _/ |    |    built with JDK 21.0.10+7-LTS, running under Java 21.0.10.
|    |   | |    |   \ |    |    Executing 'report' as 'ort' on Linux                     
\________/ |____|___/ |____|    with 4 CPUs and a maximum of 5120 MiB of memory.         
                                                                                         
Environment variables:                                                                  
ORT_DATA_DIR = /home/ort/.ort                                                           
HOME = /home/ort                                                                        
JAVA_HOME = /opt/java/openjdk                                                           
ANDROID_HOME = /opt/android-sdk                                                         
                                                                                        
Looking for ORT configuration in the following file:
        /home/ort/.ort/config/config.yml (does not exist)

Generating 'CycloneDX' report(s) in thread 'DefaultDispatcher-worker-2'...
Generating 'SpdxDocument' report(s) in thread 'DefaultDispatcher-worker-3'...
Generating 'WebApp' report(s) in thread 'DefaultDispatcher-worker-4'...
Exception in thread "main" java.util.NoSuchElementException: Key (Identifier(type=NPM, namespace=, name=acorn-import-attributes, version=1.9.5), Identifier(type=NPM, namespace=, name=acorn, version=8.16.0)) is missing in the map.
	at kotlin.collections.MapsKt__MapWithDefaultKt.getOrImplicitDefaultNullable(MapWithDefault.kt:24)
	at kotlin.collections.MapsKt__MapsKt.getValue(Maps.kt:398)
	at org.ossreviewtoolkit.plugins.reporters.spdx.SpdxDocumentModelMapper.map$addDependencyRelationships(SpdxDocumentModelMapper.kt:74)
	at org.ossreviewtoolkit.plugins.reporters.spdx.SpdxDocumentModelMapper.map(SpdxDocumentModelMapper.kt:125)
	at org.ossreviewtoolkit.plugins.reporters.spdx.SpdxDocumentReporter.generateReport(SpdxDocumentReporter.kt:124)
	at org.ossreviewtoolkit.plugins.commands.reporter.ReportCommand$run$reportDurationMap$1$1$1$1.invokeSuspend(ReportCommand.kt:316)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
Error: Process completed with exit code 1.
```

- https://github.com/epam/ai-dial-admin-frontend/actions/runs/25484057292/job/74775029304
- https://github.com/epam/ai-dial-rag/actions/runs/25484933695/job/74781546858
- and more