### PR TITLE
chore: increase timeout-minutes for deploy job of deploy-review command

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.client_payload.slash_command.args.named.environment || 'dial-review' }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       test-applications: ${{ steps.test-applications.outputs.json }}
     steps:


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

`timeout-minutes` for `deploy-review` job in `deploy-review-command` workflow was increased (30 -> 45).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
