### PR TITLE
feat: add ability to create stable GitHub releases as drafts

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.1.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.2.0
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -91,7 +91,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -131,7 +131,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -139,7 +139,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -7,6 +7,10 @@ on:
         type: boolean
         description: Promote release to stable (for release-* branches only)
         default: false
+      draft-stable-releases:
+        type: boolean
+        description: Create stable GitHub releases as drafts
+        default: false
       bypass-checks:
         type: boolean
         description: Do not fail pipeline if checks failed
@@ -159,3 +163,4 @@ jobs:
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
+          draft-stable-releases: ${{ inputs.draft-stable-releases }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -132,7 +132,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -173,7 +173,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -181,7 +181,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -189,7 +189,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -210,7 +210,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -7,6 +7,10 @@ on:
         type: boolean
         description: Promote release to stable (for release-* branches only)
         default: false
+      draft-stable-releases:
+        type: boolean
+        description: Create stable GitHub releases as drafts
+        default: false
       bypass-checks:
         type: boolean
         default: false
@@ -211,6 +215,7 @@ jobs:
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
+          draft-stable-releases: ${{ inputs.draft-stable-releases }}
           extra-commit-command: |
             git add build.gradle
             git commit -m '[skip ci] Update version' || true # upstream branch may already be updated

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -143,7 +143,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -131,7 +131,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -171,7 +171,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -179,7 +179,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -190,7 +190,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -253,7 +253,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -7,6 +7,10 @@ on:
         type: boolean
         description: Promote release to stable (for release-* branches only)
         default: false
+      draft-stable-releases:
+        type: boolean
+        description: Create stable GitHub releases as drafts
+        default: false
       bypass-checks:
         type: boolean
         description: Do not fail pipeline if checks failed
@@ -254,6 +258,7 @@ jobs:
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
+          draft-stable-releases: ${{ inputs.draft-stable-releases }}
           extra-commit-command: |
             git add package.json package-lock.json
             git commit -m '[skip ci] Update version' || true # upstream branch may already be updated

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -113,7 +113,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -153,7 +153,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -165,7 +165,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.1.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -7,6 +7,10 @@ on:
         type: boolean
         description: Promote release to stable (for release-* branches only)
         default: false
+      draft-stable-releases:
+        type: boolean
+        description: Create stable GitHub releases as drafts
+        default: false
       bypass-checks:
         type: boolean
         description: Do not fail pipeline if checks failed
@@ -185,6 +189,7 @@ jobs:
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
+          draft-stable-releases: ${{ inputs.draft-stable-releases }}
           extra-commit-command: |
             git add pyproject.toml
             git commit -m '[skip ci] Update version' || true # upstream branch may already be updated

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -7,6 +7,10 @@ on:
         type: boolean
         description: Promote release to stable (for release-* branches only)
         default: false
+      draft-stable-releases:
+        type: boolean
+        description: Create stable GitHub releases as drafts
+        default: false
       bypass-checks:
         type: boolean
         description: Do not fail pipeline if checks failed
@@ -148,6 +152,7 @@ jobs:
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}
           changelog-file: "/tmp/my_changelog" # comes from generate_release_notes step; TODO: beautify
+          draft-stable-releases: ${{ inputs.draft-stable-releases }}
           artifacts: "dist/*"
           extra-commit-command: |
             git add pyproject.toml

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -110,7 +110,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.1.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -124,7 +124,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.1.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -132,7 +132,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -147,7 +147,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.1.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.1.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/actions/publish_tag_release/action.yml
+++ b/actions/publish_tag_release/action.yml
@@ -41,6 +41,7 @@ runs:
         bodyFile: ${{ inputs.changelog-file }}
         allowUpdates: true
         updateOnlyUnreleased: true
+        omitDraftDuringUpdate: true
         draft: ${{ fromJSON(inputs.draft-stable-releases) && !contains(inputs.tag-version, '-') }} # draft if it's a stable release and the input is 'true'
         prerelease: ${{ contains(inputs.tag-version, '-') }} # will capture e.g. `-rc`
         makeLatest: ${{ contains(inputs.tag-version, '-') && 'false' || 'legacy' }} # false if it's a pre-release, otherwise let GitHub decide (based on semver)

--- a/actions/publish_tag_release/action.yml
+++ b/actions/publish_tag_release/action.yml
@@ -15,6 +15,9 @@ inputs:
   artifacts:
     description: Artifacts to upload
     default: ""
+  draft-stable-releases:
+    description: Create stable GitHub releases as drafts
+    default: "false"
 
 runs:
   using: "composite"
@@ -38,6 +41,7 @@ runs:
         bodyFile: ${{ inputs.changelog-file }}
         allowUpdates: true
         updateOnlyUnreleased: true
+        draft: ${{ fromJSON(inputs.draft-stable-releases) && !contains(inputs.tag-version, '-') }} # draft if it's a stable release and the input is 'true'
         prerelease: ${{ contains(inputs.tag-version, '-') }} # will capture e.g. `-rc`
         makeLatest: ${{ contains(inputs.tag-version, '-') && 'false' || 'legacy' }} # false if it's a pre-release, otherwise let GitHub decide (based on semver)
         tag: ${{ inputs.tag-version }}


### PR DESCRIPTION
Pass a `draft-stable-releases: true` input to any `*_release.yml` workflow to create all "stable" GitHub releases as **drafts**, e.g.:

```yaml
name: Release Workflow
    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@main
    with:
      draft-stable-releases: true
```   