### PR TITLE
feat: make review env availability check script generic

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -182,22 +182,18 @@ jobs:
     steps:
       - name: Wait for environment
         run: |
-          echo "Expected environment URL ${ENVIRONMENT_URL}, waiting to be available..."
-          env_hostname=$(echo "$ENVIRONMENT_URL" | awk -F/ '{print $3}')
+          #!/bin/bash
 
           wait_for_dns() {
-              local domain="$1"
-              local attempt=0
-              local attempt_limit=90  # retry resolve up to 15 minutes
-              local attempt_delay=10  # 10 seconds between resolve attempts
+              local hostname=$(echo "$1" | awk -F/ '{print $3}')               # remove protocol and path, e.g. "https://app.example.com:8080/health" -> "app.example.com:8080"
+              local domain=${hostname%%:*}                                     # remove port, e.g. "app.example.com:8080" -> "app.example.com"
+              local base_domain=$(echo "$domain" | sed -E 's/[^.]+\.(.+)/\1/') # extract parent domain, e.g. "app.example.com" -> "example.com"
 
-              if [ -z "$domain" ]; then
-                  echo "Specify domain name as first argument" >&2
-                  return 1
-              fi
+              local attempt=1
+              local attempt_delay=10 # seconds between attempts
+              local attempt_limit=60 # number of attempts
 
-              local base_domain=$(echo "$domain" | sed -E 's/[^.]+\.(.+)/\1/')
-              echo "Query Google public DNS for $base_domain nameservers"
+              echo "DNS check: get NS record for $domain"
               local ns_servers=$(dig +short @8.8.8.8 ns $base_domain)
               if [ -n "$ns_servers" ]; then
                   echo "Detected nameservers for $base_domain:"
@@ -209,32 +205,62 @@ jobs:
 
               local ns
               local result
-              for ns in $ns_servers
-              do
-                  while true
-                      do
-                      echo "Query $ns for $domain"
-                      result=$(dig +short @${ns} "$domain")
-                      if [ ! -z "$result" ]; then
-                          if echo "$result" | grep -Eq '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'; then
-                              echo "$result"
-                              break
-                          fi
-                      fi
-                      attempt=$((attempt+1))
-                      if [ $attempt -le $attempt_limit ]; then
-                          sleep $attempt_delay
-                      else
-                          echo "Unable to resolve $domain" >&2
-                          return 1
+              while [ $attempt -le $attempt_limit ]; do
+                  for ns in $ns_servers; do
+                      echo "Attempt $attempt/$attempt_limit: query $ns for $domain"
+                      result=$(dig +short @"${ns}" "$domain")
+                      if [ -n "$result" ] && echo "$result" | grep -Eq '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'; then
+                          echo "Resolved: $result"
+                          return 0
                       fi
                   done
+                  if [ $attempt -lt $attempt_limit ]; then
+                      sleep $attempt_delay
+                  fi
+                  attempt=$((attempt + 1))
               done
+              echo "Unable to resolve $domain" >&2
+              return 1
           }
 
-          wait_for_dns ${env_hostname}
+          wait_for_http() {
+              local url="$1"
+              local attempt=1
+              local attempt_delay=10             # seconds between attempts
+              local attempt_limit=60             # number of attempts
+              local http_success_threshold="400" # treat any HTTP code below this as success
+              local http_success_codes="401 404" # treat these HTTP codes as success
+              local http_fail_codes=""           # treat these HTTP codes as non-recoverable failure
 
-          curl --retry 30 --retry-delay 10 --retry-all-errors --fail --insecure --no-progress-meter --location --head -o /dev/null -w "%{http_code}\n" -X GET "${ENVIRONMENT_URL}"/api/health
+              printf "HTTP check: GET %s\n" "$url"
+              while [ $attempt -le $attempt_limit ]; do
+                  local curl_exit=0
+                  local http_code
+                  http_code=$(curl --disable --insecure --no-progress-meter --no-fail --max-time 10 --location --proto-redir https --output /dev/null --write-out "%{http_code}" "$url") || curl_exit=$?
+                  if [ $curl_exit -ne 0 ]; then
+                      echo "Attempt $attempt/$attempt_limit: curl error (exit $curl_exit), exiting..." >&2
+                      return $curl_exit
+                  elif echo " $http_fail_codes " | grep -q " $http_code "; then
+                      echo "Attempt $attempt/$attempt_limit: HTTP $http_code, exiting..." >&2
+                      return 1
+                  elif echo " $http_success_codes " | grep -q " $http_code " || [ "$http_code" -lt "$http_success_threshold" ]; then
+                      echo "HTTP $http_code - success"
+                      return 0
+                  else
+                      echo "Attempt $attempt/$attempt_limit: HTTP $http_code, retrying..."
+                  fi
+                  if [ $attempt -lt $attempt_limit ]; then
+                      sleep $attempt_delay
+                  fi
+                  attempt=$((attempt + 1))
+              done
+              printf "HTTP check failed for %s\n" "$url" >&2
+              return 1
+          }
+
+          printf "Environment URL is '%s', waiting to be available...\n" "$ENVIRONMENT_URL"
+          wait_for_dns "${ENVIRONMENT_URL}"
+          wait_for_http "${ENVIRONMENT_URL}"
         shell: bash
         env:
           ENVIRONMENT_URL: ${{ env.ENVIRONMENT_URL }}


### PR DESCRIPTION
Improve "Wait for environment" script by:
- probing given path instead of hardcoded `/api/health`
- refactoring HTTP probe from plain curl to bash logic. This allows to set custom success codes, e.g. `401` for fully restricted apps or `404` for apps that does not serve on `/`, etc. The refactored code provides extended control on retries, but mimics previous curl behavior in other aspects
- query ALL name servers instead of first one in `wait_for_dns`
- add connection timeout for HTTP probes
- minor optimizations and enhancements