### PR TITLE
fix: npm publish script should not use reserved name "publish"

### DIFF
--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -235,14 +235,9 @@ jobs:
           else
             npm run build
           fi
-          if node -e "process.exit(require('./package.json').scripts?.['publish:npm'] ? 0 : 1)"; then
-            HAS_PUBLISH_NPM_SCRIPT=true
-          else
-            HAS_PUBLISH_NPM_SCRIPT=false
-          fi
           publish_with_tag() {
             local tag="$1"
-            if [ "$HAS_PUBLISH_NPM_SCRIPT" = "true" ]; then
+            if node -e "process.exit(require('./package.json').scripts?.['publish:npm'] ? 0 : 1)"; then
               npm run publish:npm -- --tag "$tag"
             else
               npm publish --tag "$tag"

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -219,7 +219,7 @@ jobs:
           # Steps:
           # 1. (naive) check if a package with the same version is already exists in the registry
           # 2. build the package using either `build:publishable` (useful for monorepos) or `build` script
-          # 3. publish the package using `publish` script with distribution tags:
+          # 3. publish the package using `publish:npm` script (if exists) or `npm publish` directly with distribution tags:
           #    - development branch --> `development` distribution tag
           #    - release candidate version --> `{release-line}-rc` distribution tag (e.g. `1.0-rc`)
           #    - stable version
@@ -235,15 +235,28 @@ jobs:
           else
             npm run build
           fi
+          if node -e "process.exit(require('./package.json').scripts?.['publish:npm'] ? 0 : 1)"; then
+            HAS_PUBLISH_NPM_SCRIPT=true
+          else
+            HAS_PUBLISH_NPM_SCRIPT=false
+          fi
+          publish_with_tag() {
+            local tag="$1"
+            if [ "$HAS_PUBLISH_NPM_SCRIPT" = "true" ]; then
+              npm run publish:npm -- --tag "$tag"
+            else
+              npm publish --tag "$tag"
+            fi
+          }
           if [ "$IS_DEVELOPMENT" = "true" ]; then
-            npm run publish -- --tag "development"
+            publish_with_tag "development"
           elif [ "$IS_RELEASE_CANDIDATE" = "true" ]; then
-            npm run publish -- --tag "$RELEASE_LINE-rc"
+            publish_with_tag "$RELEASE_LINE-rc"
           elif [ "$IS_RELEASE" = "true" ]; then
             if [ "$IS_LATEST" = "true" ]; then
-              npm run publish -- --tag "latest"
+              publish_with_tag "latest"
             else
-              npm run publish -- --tag "release-$RELEASE_LINE"
+              publish_with_tag "release-$RELEASE_LINE"
             fi
           fi
         env:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Changelog is automatically generated based on git commit history (commit message
 
 Consumer repository **must** have:
 
-- `package.json` file with `format`, `lint`, `test`, `build`, and `publish` scripts defined
+- `package.json` file with `format`, `lint`, `test`, `build`, and `publish:npm` scripts defined
 
 `package.json`
 
@@ -141,7 +141,7 @@ Consumer repository **must** have:
     "lint": "eslint .",
     "test": "jest",
     "build": "tsc",
-    "publish": "npm publish"
+    "publish:npm": "npm publish"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Changelog is automatically generated based on git commit history (commit message
 
 Consumer repository **must** have:
 
-- `package.json` file with `format`, `lint`, `test`, `build`, and `publish:npm` scripts defined
+- `package.json` file with `format`, `lint`, `test`, `build` scripts defined
 
 `package.json`
 
@@ -140,8 +140,7 @@ Consumer repository **must** have:
     "format": "prettier --check .",
     "lint": "eslint .",
     "test": "jest",
-    "build": "tsc",
-    "publish:npm": "npm publish"
+    "build": "nx run-many -t build",
   }
 }
 ```
@@ -153,7 +152,10 @@ Consumer repository **must** have:
 > We require script *names* only, not specific implementations - you can use any tools you like as long as you provide the required scripts
 
 > [!tip]
-> If a `build:publishable` script exists, it takes precedence over `build` for the release build (useful in monorepos)
+> If a `build:publishable` script exists, it takes precedence over `build` for building the package. Useful in monorepos to avoid building the whole repository when only subset should be published, e.g. `"build:publishable": "nx run-many -t build --projects=tag:publishable"`
+
+> [!tip]
+> If a `publish:npm` script exists, it takes precedence over regular `npm publish` command for publishing the package. This allows to implement any custom publish logic. The custom script will receive desired distribution tag as a `--tag` argument
 
 #### PR Workflow
 


### PR DESCRIPTION
Issue with npmjs publishing. Command `npm run publish` runs script `publish` which creates a loop and fails the CI.
Example:
https://github.com/epam/ai-dial-typescript-sdk/actions/runs/26276728733/job/77343161116
```log
Run #!/bin/bash

> @epam/ai-dial-typescript-sdk@0.1.0-dev.11 build
...
> @epam/ai-dial-typescript-sdk@0.1.0-dev.11 publish
> npm publish --access public --tag development
...
> @epam/ai-dial-typescript-sdk@0.1.0-dev.11 publish
> npm publish --access public
....
npm error code E403
...
Error: Process completed with exit code 1.
```

The fix: script name was renamed from `publish` to `publish:npm`

Also as was spoken, added logic when npm script defined in `package.json` and when it is missing.
