### PR TITLE
feat: add support of trusted publishing to npmjs registry 

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.2.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.3.0
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -91,7 +91,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -131,7 +131,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -139,7 +139,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -132,7 +132,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -173,7 +173,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -181,7 +181,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -189,7 +189,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -210,7 +210,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -143,7 +143,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -138,10 +138,10 @@ jobs:
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:
-      id-token: write
       contents: write
-      packages: write
-      security-events: write
+      id-token: write # for trusted publishing to npmjs registry
+      packages: write # for publishing to GitHub Packages registry
+      security-events: write # for uploading Trivy SARIF report to GitHub
     needs:
       - calculate_version
       - test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -131,7 +131,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -172,7 +172,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -180,7 +180,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -191,7 +191,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -262,7 +262,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -138,6 +138,7 @@ jobs:
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:
+      id-token: write
       contents: write
       packages: write
       security-events: write

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -113,7 +113,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -153,7 +153,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -165,7 +165,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.2.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -110,7 +110,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.2.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -124,7 +124,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.2.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -132,7 +132,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -147,7 +147,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.2.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.2.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# required only for trusted publishing package to mpmjs registry 
+permissions:
+  id-token: write
+
 jobs:
   release:
     uses: epam/ai-dial-ci/.github/workflows/node_release.yml@main
@@ -206,6 +210,12 @@ jobs:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
     secrets: inherit
 ```
+> [!NOTE]
+> While publishing a public package to npmjs, there are 2 options how to provide credentials.
+>
+> **Option 1:** Create NPM access token -> add token to NPM_TOKEN GitHub variable (Settings - Secrets and variables - Actions) -> make first publish -> Create granular token and update NPM_TOKEN variable.
+>
+> **Option 2:** Create NPM access token -> add token to NPM_TOKEN GitHub variable (Settings - Secrets and variables - Actions) -> make first publish -> Configure OIDC provider in npmjs package settings using [official documentation](https://docs.npmjs.com/trusted-publishers) -> configure GitHub workflow with necessary permisions (see permissions in yaml file above) -> delete NPM_TOKEN variable.
 
 ### Java (gradle)
 

--- a/README.md
+++ b/README.md
@@ -128,34 +128,40 @@ Changelog is automatically generated based on git commit history (commit message
 
 Consumer repository **must** have:
 
-- `package.json` file with `format`, `lint`, `test`, `build` scripts defined
+- `package.json` file with `format`, `lint`, `test`, `build` scripts defined. We require scripts to exist, but not restrict their implementation - you can use any tools you like.
 
-`package.json`
+  <details>
+    <summary>Example</summary>
 
-```json
-{
-  "name": "@scope/my-package",
-  "version": "0.0.0",
-  "scripts": {
-    "format": "prettier --check .",
-    "lint": "eslint .",
-    "test": "jest",
-    "build": "nx run-many -t build",
-  }
-}
-```
+    ```json
+    {
+      "name": "@scope/my-package",
+      "version": "0.0.0",
+      "scripts": {
+        "format": "prettier --check .",
+        "lint": "eslint .",
+        "test": "jest",
+        "build": "nx run-many -t build",
+      }
+    }
+    ```
 
-> [!warning]
-> The `version` value is updated by CI/CD automation - please do not modify it manually. See more details in [Branching](#branching) section
+    > [!warning]
+    > The `version` value is updated by CI/CD automation - please do not modify it manually. See more details in [Branching](#branching) section
 
-> [!tip]
-> We require script *names* only, not specific implementations - you can use any tools you like as long as you provide the required scripts
+    > [!tip]
+    > If a `build:publishable` script exists, it takes precedence over `build` for building the package. Useful in monorepos to avoid building the whole repository when only subset should be published, e.g. `"build:publishable": "nx run-many -t build --projects=tag:publishable"`
 
-> [!tip]
-> If a `build:publishable` script exists, it takes precedence over `build` for building the package. Useful in monorepos to avoid building the whole repository when only subset should be published, e.g. `"build:publishable": "nx run-many -t build --projects=tag:publishable"`
+    > [!tip]
+    > If a `publish:npm` script exists, it takes precedence over regular `npm publish` command for publishing the package. This allows to implement any custom publish logic. The custom script will receive desired distribution tag as a `--tag` argument
+  </details>
 
-> [!tip]
-> If a `publish:npm` script exists, it takes precedence over regular `npm publish` command for publishing the package. This allows to implement any custom publish logic. The custom script will receive desired distribution tag as a `--tag` argument
+- Authentication to npm registry
+
+  While publishing a package to [npm registry](https://npmjs.com), we support 2 options how to provide credentials.
+
+  - (recommended) [Trusted publishing](https://docs.npmjs.com/trusted-publishers): grant release GitHub workflow `id-token: write` permission (see [example](#release-workflow))
+  - [Granular access token](https://docs.npmjs.com/creating-and-viewing-access-tokens): create a token and store it as `NPM_TOKEN` [repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
 
 #### PR Workflow
 
@@ -199,8 +205,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# required only for trusted publishing package to mpmjs registry 
 permissions:
+  contents: write
+  packages: write
+  security-events: write
   id-token: write
 
 jobs:
@@ -210,35 +218,31 @@ jobs:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
     secrets: inherit
 ```
-> [!NOTE]
-> While publishing a public package to npmjs, there are 2 options how to provide credentials.
->
-> **Option 1:** Create NPM access token -> add token to NPM_TOKEN GitHub variable (Settings - Secrets and variables - Actions) -> make first publish -> Create granular token and update NPM_TOKEN variable.
->
-> **Option 2:** Create NPM access token -> add token to NPM_TOKEN GitHub variable (Settings - Secrets and variables - Actions) -> make first publish -> Configure OIDC provider in npmjs package settings using [official documentation](https://docs.npmjs.com/trusted-publishers) -> configure GitHub workflow with necessary permisions (see permissions in yaml file above) -> delete NPM_TOKEN variable.
 
 ### Java (gradle)
 
 #### Requirements
 
-Consumer repository must have:
+Consumer repository **must** have:
 
 - `build.gradle` with `check`, `checkstyleMain` and `build` tasks exposed
 
-`build.gradle`
+  <details>
+    <summary>Example</summary>
 
-```groovy
-plugins {
-    id "java" // exposes `check`, `build` tasks
-    id "checkstyle" // exposes `checkstyleMain` task
-}
+  ```groovy
+  plugins {
+      id "java" // exposes `check`, `build` tasks
+      id "checkstyle" // exposes `checkstyleMain` task
+  }
 
-group = "org.example"
-version = "0.0.0"
-```
+  group = "org.example"
+  version = "0.0.0"
+  ```
 
-> [!warning]
-> The `version` value is updated by CI/CD automation - please do not modify it manually. See more details in [Branching](#branching) section
+  > [!warning]
+  > The `version` value is updated by CI/CD automation - please do not modify it manually. See more details in [Branching](#branching) section
+  </details>
 
 #### PR Workflow (Docker)
 
@@ -427,52 +431,57 @@ jobs:
 
 #### Requirements
 
-Consumer repository must have:
+Consumer repository **must** have:
 
 - `Makefile` file with `lint`, `build` (only for Python packages), `test`, `publish` (only for Python packages) targets defined
+
+  <details>
+    <summary>Example</summary>
+
+  ```makefile
+  PORT ?= 5001
+
+  .PHONY: install lint build test publish
+
+  install:
+    poetry install --all-extras
+
+  lint: install
+    poetry run ruff check .
+    poetry run ruff format --check .
+
+  build: install # Required only for Python packages
+    poetry build
+
+  test: install
+    if [ -n "$(PYTHON)" ]; then poetry env use "$(PYTHON)"; fi
+    poetry run pytest
+
+  publish: # Required only for Python packages
+    poetry publish --username __token__ --password $(PYPI_TOKEN) --skip-existing
+  ```
+
+  > [!note]
+  > `build` and `publish` Makefile targets are required only for repositories that produce Python packages as build artifacts
+
+  > [!tip]
+  > `test` target receives Python version, e.g. `make test PYTHON=<version>`, where `<version>` is the one defined in `code-checks-python-versions` workflow input. If multiple versions are defined, the workflow will run tests for each of them in parallel
+  </details>
+
 - `pyproject.toml` file with `name` and `version` defined
 
-`Makefile`
+  <details>
+    <summary>Example</summary>
 
-```makefile
-PORT ?= 5001
+  ```toml
+  [project]
+  name = "my-package"
+  version = "0.0.0"
+  ```
 
-.PHONY: install lint build test publish
-
-install:
-	poetry install --all-extras
-
-lint: install
-	poetry run ruff check .
-	poetry run ruff format --check .
-
-build: install # Required only for Python packages
-	poetry build
-
-test: install
-	if [ -n "$(PYTHON)" ]; then poetry env use "$(PYTHON)"; fi
-	poetry run pytest
-
-publish: # Required only for Python packages
-	poetry publish --username __token__ --password $(PYPI_TOKEN) --skip-existing
-```
-
-`pyproject.toml`
-
-```toml
-[project]
-name = "my-package"
-version = "0.0.0"
-```
-
-> [!warning]
-> The `version` value is updated by CI/CD automation - please do not modify it manually. See more details in [Branching](#branching) section
-
-> [!note]
-> `build` and `publish` Makefile targets are required only for repositories that produce Python packages as build artifacts
-
-> [!tip]
-> `test` target receives Python version, e.g. `make test PYTHON=<version>`, where `<version>` is the one defined in `code-checks-python-versions` workflow input. If multiple versions are defined, the workflow will run tests for each of them in parallel
+  > [!warning]
+  > The `version` value is updated by CI/CD automation - please do not modify it manually. See more details in [Branching](#branching) section
+  </details>
 
 #### PR Workflow (Docker)
 
@@ -578,33 +587,37 @@ jobs:
 
 #### Requirements
 
-Consumer repository must have:
+Consumer repository **must** have:
 
 - `Makefile` with `lint` target defined
+
+  <details>
+    <summary>Example</summary>
+
+    ```makefile
+    .PHONY: all lint build run help
+
+    all: lint build
+
+    build:
+      docker build -t my-image .
+
+    run:
+      docker run my-image
+
+    lint:
+      docker run --rm -i hadolint/hadolint < Dockerfile
+
+    help:
+      @echo '===================='
+      @echo 'lint                         - lint the Dockerfile'
+      @echo 'build                        - build docker image'
+      @echo 'run                          - run docker image'
+    ```
+
+  </details>
+
 - `Dockerfile`
-
-`Makefile`
-
-```makefile
-.PHONY: all lint build run help
-
-all: lint build
-
-build:
-	docker build -t my-image .
-
-run:
-	docker run my-image
-
-lint:
-	docker run --rm -i hadolint/hadolint < Dockerfile
-
-help:
-	@echo '===================='
-	@echo 'lint                         - lint the Dockerfile'
-	@echo 'build                        - build docker image'
-	@echo 'run                          - run docker image'
-```
 
 #### PR Workflow
 


### PR DESCRIPTION
Changes requied for using trusted publishing to npmjs registry. 
Per recommendation listed in guide:
https://docs.npmjs.com/trusted-publishers#troubleshooting
The id-token: write permission must also be given to both parent and child workflows.

Last successful run would be https://github.com/epam/ai-dial-typescript-sdk/actions/runs/26276728733/job/77343161116