### PR TITLE
feat: make ORT config source configurable

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.3.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.3.1
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -27,6 +27,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -73,6 +81,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       runs-on: ${{ inputs.runs-on }}
 
   docker_build:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -34,7 +34,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -35,6 +35,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -81,6 +89,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       runs-on: ${{ inputs.runs-on }}
 
   calculate_version:

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -42,7 +42,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -101,7 +101,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -141,7 +141,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -149,7 +149,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -27,6 +27,14 @@ on:
         type: string
         description: ORT version to use
         default: "latest"
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
       runs-on:
         type: string
         description: Overrides jobs runs-on settings (json-encoded list)
@@ -62,5 +70,6 @@ jobs:
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace"
-          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
+          ort-config-repository: ${{ inputs.ort-config-repository }}
+          ort-config-revision: ${{ inputs.ort-config-revision }}
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -57,10 +57,10 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
-          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace"
+          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -35,6 +35,14 @@ on:
         type: string
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
         description: ORT version to use
+      ort-config-repository:
+        type: string
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        description: ORT config repository to use
+      ort-config-revision:
+        type: string
+        default: "main"
+        description: ORT config revision to use
       trivy-enabled:
         type: boolean
         default: true
@@ -91,6 +99,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       java-version: ${{ inputs.java-version }}
       java-distribution: ${{ inputs.java-distribution }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -41,7 +41,7 @@ on:
         description: ORT config repository to use
       ort-config-revision:
         type: string
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
         description: ORT config revision to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -142,7 +142,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -183,7 +183,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -191,7 +191,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -220,7 +220,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -43,6 +43,14 @@ on:
         type: string
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
         description: ORT version to use
+      ort-config-repository:
+        type: string
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        description: ORT config repository to use
+      ort-config-revision:
+        type: string
+        default: "main"
+        description: ORT config revision to use
       trivy-enabled:
         type: boolean
         default: true
@@ -99,6 +107,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       java-version: ${{ inputs.java-version }}
       java-distribution: ${{ inputs.java-distribution }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -49,7 +49,7 @@ on:
         description: ORT config repository to use
       ort-config-revision:
         type: string
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
         description: ORT config revision to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.3.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -120,10 +120,10 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
-          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Gradle"
+          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -120,6 +120,7 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -39,6 +39,14 @@ on:
         type: string
         default: "latest"
         description: ORT version to use
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
       java-version:
         type: string
         default: "17"
@@ -125,5 +133,6 @@ jobs:
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Gradle"
-          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
+          ort-config-repository: ${{ inputs.ort-config-repository }}
+          ort-config-revision: ${{ inputs.ort-config-revision }}
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -50,7 +50,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -153,7 +153,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -43,6 +43,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"
@@ -105,6 +113,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       node-version: ${{ inputs.node-version }}
       runs-on: ${{ inputs.runs-on }}
 

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -58,7 +58,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -51,6 +51,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"
@@ -117,6 +125,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       node-version: ${{ inputs.node-version }}
       runs-on: ${{ inputs.runs-on }}
 

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -141,7 +141,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -182,7 +182,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -190,7 +190,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -201,7 +201,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -272,7 +272,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -114,10 +114,10 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
-          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=NPM"
+          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -114,6 +114,7 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.3.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -43,6 +43,14 @@ on:
         type: string
         description: ORT version to use
         default: "latest"
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
       node-version:
         type: string
         description: NodeJS version to use
@@ -119,5 +127,6 @@ jobs:
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=NPM"
-          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
+          ort-config-repository: ${{ inputs.ort-config-repository }}
+          ort-config-revision: ${{ inputs.ort-config-revision }}
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -42,7 +42,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -35,6 +35,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -91,6 +99,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       python-version: ${{ inputs.python-version }}
       poetry-version: ${{ inputs.poetry-version }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -43,6 +43,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -99,6 +107,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       python-version: ${{ inputs.python-version }}
       poetry-version: ${{ inputs.poetry-version }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -50,7 +50,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -123,7 +123,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -163,7 +163,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -175,7 +175,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.3.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.3.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -194,7 +194,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -149,10 +149,10 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
-          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"
+          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -149,6 +149,7 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -35,6 +35,14 @@ on:
         type: string
         description: ORT version to use
         default: "latest"
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
       python-version:
         type: string
         description: Python version to use
@@ -154,5 +162,6 @@ jobs:
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"
-          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
+          ort-config-repository: ${{ inputs.ort-config-repository }}
+          ort-config-revision: ${{ inputs.ort-config-revision }}
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -46,7 +46,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -39,6 +39,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -88,6 +96,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       trivy-enabled: ${{ inputs.trivy-enabled }}
       trivy-bypassed: ${{ inputs.trivy-bypassed }}
       trivy-severity: ${{ inputs.trivy-severity }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -47,6 +47,14 @@ on:
         type: string
         description: ORT version to use
         default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: "main"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -93,6 +101,8 @@ jobs:
       ort-enabled: ${{ inputs.ort-enabled }}
       ort-bypassed: ${{ inputs.ort-bypassed }}
       ort-version: ${{ inputs.ort-version }}
+      ort-config-repository: ${{ inputs.ort-config-repository }}
+      ort-config-revision: ${{ inputs.ort-config-revision }}
       trivy-enabled: ${{ inputs.trivy-enabled }}
       trivy-bypassed: ${{ inputs.trivy-bypassed }}
       trivy-severity: ${{ inputs.trivy-severity }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -54,7 +54,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "main"
+        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -120,7 +120,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.3.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -134,7 +134,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.3.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -142,7 +142,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -157,7 +157,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.3.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           tag-version: ${{ needs.calculate_version.outputs.next-version }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -140,12 +140,12 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
-          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"
+          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
 
   trivy:

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.3.1
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -140,6 +140,7 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
         env:
           CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+          ORT_CONFIG_VCS_REVISION: 5650fed55a20397b9abb9017a0c6bb674dc8481d
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -71,6 +71,14 @@ on:
         type: string
         description: ORT version to use
         default: "latest"
+      ort-config-repository:
+        type: string
+        description: ORT config repository to use
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+      ort-config-revision:
+        type: string
+        description: ORT config revision to use
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
       python-version:
         type: string
         description: Python version to use
@@ -145,7 +153,8 @@ jobs:
           allow-dynamic-versions: "true"
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"
-          ort-config-revision: 5650fed55a20397b9abb9017a0c6bb674dc8481d
+          ort-config-repository: ${{ inputs.ort-config-repository }}
+          ort-config-revision: ${{ inputs.ort-config-revision }}
         continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
 
   trivy:


### PR DESCRIPTION
Fixes `https://github.com/oss-review-toolkit/ort-config/issues/431` by adding possibility to set `ORT_CONFIG_VCS_URL`, `ORT_CONFIG_VCS_REVISION` as repository variables OR passing as `ort-config-repository`, `ort-config-revision` workflow inputs.
