### PR TITLE
fix: bump minor for dev version after release candidate found

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.4.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.4.1
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -101,7 +101,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -141,7 +141,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -149,7 +149,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -142,7 +142,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -183,7 +183,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -191,7 +191,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -220,7 +220,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.4.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -153,7 +153,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -141,7 +141,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -182,7 +182,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -190,7 +190,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -201,7 +201,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -272,7 +272,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.4.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           image-name: ghcr.io/${{ env.IMAGE_NAME }}
           image-tag: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -123,7 +123,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -163,7 +163,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -175,7 +175,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.4.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.4.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -194,7 +194,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.next-version || 'development' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}:{1}', env.IMAGE_NAME, 'latest') || '' }}
             ${{ startsWith(github.ref, 'refs/heads/release-') && needs.calculate_version.outputs.is-latest == 'true' && format('{0}/{1}:{2}', 'ghcr.io', env.IMAGE_NAME, 'latest') || '' }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -120,7 +120,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.4.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -134,7 +134,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.4.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -142,7 +142,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -157,7 +157,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.4.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.4.1
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -128,7 +128,7 @@ runs:
             rc)
               DEV_N=$(git rev-list --count "${LATEST_RC_TAG}..HEAD")
               CURRENT_VERSION="${LATEST_RC_TAG}"
-              NEXT_VERSION="${LATEST_RC_LINE}.0-dev.${DEV_N}"
+              NEXT_VERSION=$(bump_version "${LATEST_RC_LINE}.0" --minor --pre-release "-dev.${DEV_N}")
               ;;
             *)
               DEV_N=$(git rev-list --count HEAD)

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -187,10 +187,10 @@ gitGraph
 
 | Output                         | Expected value                     |
 | ------------------------------ | ---------------------------------- |
-| Next version                   | `1.0.0-dev.1`                      |
+| Next version                   | `1.1.0-dev.1`                      |
 | Git tag                        | -                                  |
 | Container tags                 | `IMAGE:development`                |
-| npm artifacts (`tag: version`) | `development: 1.0.0-dev.1` created |
+| npm artifacts (`tag: version`) | `development: 1.1.0-dev.1` created |
 | GitHub Release                 | -                                  |
 | Release changelog              | -                                  |
 
@@ -205,7 +205,7 @@ docker manifest inspect $IMAGE:development
 
 npm dist-tag ls $PKG
 # --> 1.0-rc: 1.0.0-rc.0
-#     development: 1.0.0-dev.1
+#     development: 1.1.0-dev.1
 
 gh release list
 # --> 1.0.0-rc.0  Pre-release  (1.0.0-rc.0)
@@ -252,7 +252,7 @@ docker manifest inspect $IMAGE:1.0.0-rc.1
 
 npm dist-tag ls $PKG
 # --> 1.0-rc: 1.0.0-rc.1
-#     development: 1.0.0-dev.1
+#     development: 1.1.0-dev.1
 
 gh release view 1.0.0-rc.1 --json isPrerelease
 # --> {"isPrerelease":true}
@@ -310,7 +310,7 @@ docker manifest inspect $IMAGE:latest
 
 npm dist-tag ls $PKG
 # --> 1.0-rc: 1.0.0-rc.1
-#     development: 1.0.0-dev.1
+#     development: 1.1.0-dev.1
 #     latest: 1.0.0
 
 gh release view 1.0.0 --json isPrerelease
@@ -325,7 +325,7 @@ gh release view 1.0.0 --json body | jq -r '.body'
 ### Scenario 6 - Sequential push of 2 commits to `development` after stable `1.0.0` exists
 
 **Pre-conditions:** End state of Scenario 5. Tags: `1.0.0`, `1.0.0-rc.1`, `1.0.0-rc.0`.
-npm: `latest: 1.0.0`, `1.0-rc: 1.0.0-rc.1`, `development: 1.0.0-dev.1`.
+npm: `latest: 1.0.0`, `1.0-rc: 1.0.0-rc.1`, `development: 1.1.0-dev.1`.
 `IMAGE:latest` points to `IMAGE:1.0.0`. No `2.x` stable exists.
 
 > [!note]

--- a/test/semantic_versioning.bats
+++ b/test/semantic_versioning.bats
@@ -1,0 +1,235 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  export SCRIPT_DIR="${BATS_TEST_DIRNAME}"
+  export REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  export ACTION_FILE="${REPO_ROOT}/actions/semantic_versioning/action.yml"
+  export ACTION_RUN_SCRIPT="${BATS_FILE_TMPDIR}/calculate_version_from_action.sh"
+
+  # Parse the run-block from GitHub Action once for all tests in this file
+  awk '
+    $0 ~ /^      run: \|$/ { in_run=1; next }
+    in_run && $0 ~ /^      env:$/ { exit }
+    in_run {
+      sub(/^        /, "", $0)
+      print
+    }
+  ' "${ACTION_FILE}" > "${ACTION_RUN_SCRIPT}"
+  chmod +x "${ACTION_RUN_SCRIPT}"
+}
+
+setup() {
+  export COMMIT_COUNTER=0
+  export LAST_COMMIT_SHA=""
+}
+
+# Helper functions
+
+commit_msg() {
+  local msg="$1"
+  COMMIT_COUNTER=$((COMMIT_COUNTER + 1))
+  mkdir -p commits
+  printf "%s\n" "${msg}" >"commits/${COMMIT_COUNTER}.txt"
+  git add "commits/${COMMIT_COUNTER}.txt"
+  git commit -q -m "${msg}"
+  LAST_COMMIT_SHA=$(git rev-parse HEAD)
+}
+
+cherry_pick_commit() {
+  local sha="$1"
+  git cherry-pick -x --no-edit "${sha}" >/dev/null
+}
+
+init_dummy_repo() {
+  local repo_dir="$1"
+  mkdir -p "${repo_dir}"
+  cd "${repo_dir}"
+  git init -q --initial-branch=development
+  git config user.name "dummy"
+  git config user.email "dummy@example.com"
+
+  # HACK: add a local remote so `git fetch --tags` inside the action doesn't fail
+  git remote add origin "$(pwd)"
+}
+
+read_output_key() {
+  local key="$1"
+  grep "^${key}=" "${BATS_TEST_TMPDIR}/calc_output.txt" | tail -1 | cut -d= -f2-
+}
+
+run_calc() {
+  local promote="$1"
+
+  local GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/calc_output.txt"
+  local GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/calc_summary.md"
+
+  : >"${GITHUB_OUTPUT}"
+  : >"${GITHUB_STEP_SUMMARY}"
+
+  INPUT_PROMOTE="${promote}" \
+  GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+  GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY}" \
+  run bash "${ACTION_RUN_SCRIPT}"
+
+  if [ "$status" -ne 0 ]; then
+    echo "Action script failed with status $status:" >&3
+    echo "$output" >&3
+    return 1
+  fi
+
+  export CALC_NEXT_VERSION=$(read_output_key "next-version")
+  export CALC_IS_RELEASE_CANDIDATE=$(read_output_key "is-release-candidate")
+  export CALC_IS_RELEASE=$(read_output_key "is-release")
+  export CALC_IS_LATEST=$(read_output_key "is-latest")
+  export CALC_RELEASE_LINE=$(read_output_key "release-line")
+  export CALC_CHANGELOG_MODE=$(read_output_key "changelog-mode")
+}
+
+assert_calc() {
+  local scenario="$1"
+  local branch="$2"
+  local promote="$3"
+  local expected_next="$4"
+  local expected_is_rc="$5"
+  local expected_is_release="$6"
+  local expected_is_latest="$7"
+  local expected_release_line="$8"
+  local expected_changelog_mode="$9"
+
+  git checkout -q "${branch}"
+  run_calc "${promote}"
+
+  # Bats assertions
+  [ "${expected_next}" = "${CALC_NEXT_VERSION}" ] || { echo "FAIL ${scenario}: Expected next-version '${expected_next}', got '${CALC_NEXT_VERSION}'" >&3; return 1; }
+  [ "${expected_is_rc}" = "${CALC_IS_RELEASE_CANDIDATE}" ] || { echo "FAIL ${scenario}: Expected is-release-candidate '${expected_is_rc}', got '${CALC_IS_RELEASE_CANDIDATE}'" >&3; return 1; }
+  [ "${expected_is_release}" = "${CALC_IS_RELEASE}" ] || { echo "FAIL ${scenario}: Expected is-release '${expected_is_release}', got '${CALC_IS_RELEASE}'" >&3; return 1; }
+  [ "${expected_is_latest}" = "${CALC_IS_LATEST}" ] || { echo "FAIL ${scenario}: Expected is-latest '${expected_is_latest}', got '${CALC_IS_LATEST}'" >&3; return 1; }
+  [ "${expected_release_line}" = "${CALC_RELEASE_LINE}" ] || { echo "FAIL ${scenario}: Expected release-line '${expected_release_line}', got '${CALC_RELEASE_LINE}'" >&3; return 1; }
+  [ "${expected_changelog_mode}" = "${CALC_CHANGELOG_MODE}" ] || { echo "FAIL ${scenario}: Expected changelog-mode '${expected_changelog_mode}', got '${CALC_CHANGELOG_MODE}'" >&3; return 1; }
+}
+
+
+# ==========================================
+#                  TESTS
+# ==========================================
+
+@test "Full lifecycle scenarios (0-16)" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/full-lifecycle"
+
+  commit_msg "chore: initial commit"
+  assert_calc "S0" "development" "false" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 1"
+  assert_calc "S1" "development" "false" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.0
+  assert_calc "S2" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.0
+
+  git checkout -q development
+  commit_msg "fix: 1"
+  local sha_fix1="${LAST_COMMIT_SHA}"
+  assert_calc "S3" "development" "false" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q release-1.0
+  cherry_pick_commit "${sha_fix1}"
+  assert_calc "S4" "release-1.0" "false" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.1
+
+  assert_calc "S5" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+
+  git checkout -q development
+  commit_msg "feat: 2"
+  commit_msg "fix: 2"
+  local sha_fix2="${LAST_COMMIT_SHA}"
+  assert_calc "S6" "development" "false" "1.1.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q release-1.0
+  cherry_pick_commit "${sha_fix2}"
+  assert_calc "S7" "release-1.0" "false" "1.0.1" "false" "true" "true" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.1
+
+  git checkout -q development
+  git checkout -q -b release-1.1
+  assert_calc "S8" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.0-rc.0
+
+  assert_calc "S9" "release-1.1" "true" "1.1.0" "false" "true" "true" "1.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.0
+
+  git checkout -q development
+  commit_msg "feat: 3"
+  assert_calc "S10" "development" "false" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.2
+  assert_calc "S11" "release-1.2" "false" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.2.0-rc.0
+
+  assert_calc "S12" "release-1.2" "true" "1.2.0" "false" "true" "true" "1.2" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.2.0
+
+  git checkout -q development
+  commit_msg "fix: 3"
+  local sha_fix3="${LAST_COMMIT_SHA}"
+  commit_msg "fix: 4"
+  local sha_fix4="${LAST_COMMIT_SHA}"
+  commit_msg "fix: 5"
+  local sha_fix5="${LAST_COMMIT_SHA}"
+  assert_calc "S13" "development" "false" "1.3.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q release-1.1
+  cherry_pick_commit "${sha_fix3}"
+  assert_calc "S14" "release-1.1" "false" "1.1.1" "false" "true" "false" "1.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.1
+
+  git checkout -q release-1.2
+  cherry_pick_commit "${sha_fix4}"
+  assert_calc "S15" "release-1.2" "false" "1.2.1" "false" "true" "true" "1.2" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.2.1
+
+  git checkout -q release-1.0
+  cherry_pick_commit "${sha_fix5}"
+  assert_calc "S16" "release-1.0" "false" "1.0.2" "false" "true" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.2
+}
+
+@test "DEV_N edge regression suite" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/devn-edge"
+
+  commit_msg "chore: initial commit"
+  commit_msg "feat: 1"
+
+  git checkout -q -b release-1.0
+  assert_calc "E1" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.0
+
+  assert_calc "E2" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+
+  git checkout -q development
+  commit_msg "feat: 2"
+  assert_calc "E3" "development" "false" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.1
+  assert_calc "E4" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.0-rc.0
+
+  git checkout -q development
+  commit_msg "fix: edge-after-rc-cut"
+  assert_calc "E5" "development" "false" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+}

--- a/test/semantic_versioning.bats
+++ b/test/semantic_versioning.bats
@@ -7,14 +7,7 @@ setup_file() {
   export ACTION_RUN_SCRIPT="${BATS_FILE_TMPDIR}/calculate_version_from_action.sh"
 
   # Parse the run-block from GitHub Action once for all tests in this file
-  awk '
-    $0 ~ /^      run: \|$/ { in_run=1; next }
-    in_run && $0 ~ /^      env:$/ { exit }
-    in_run {
-      sub(/^        /, "", $0)
-      print
-    }
-  ' "${ACTION_FILE}" > "${ACTION_RUN_SCRIPT}"
+  yq '.runs.steps[] | select(.id == "calculate-version") | .run' "${ACTION_FILE}" > "${ACTION_RUN_SCRIPT}"
   chmod +x "${ACTION_RUN_SCRIPT}"
 }
 


### PR DESCRIPTION
## The issue

DEV counter increments normally on development but resets to 1 with same major.minor.patch after RC creation, causing version collisions:

| Stage             | current-version | next-version   |
| ----------------- | --------------- | -------------- |
| development run 1 | 0.45.1          | 0.46.0-dev.1 |
| development run N | 0.45.1          | 0.46.0-dev.N|
| development run 159 | 0.45.1          | 0.46.0-dev.159 |
| RC creation       |                 | 0.46.0-rc.0    |
| development run 160 | 0.46.0-rc.0     | 0.46.0-dev.1   |

This causes package publish overwrites/errors for already published versions

## The fix

- Bump the minor version together with DEV counter reset, so development moves to the next line after RC creation

  | Stage             | current-version | next-version   |
  | ----------------- | --------------- | -------------- |
  | development run 1 | 0.45.1          | 0.46.0-dev.1 |
  | development run N | 0.45.1          | 0.46.0-dev.N|
  | development run 159 | 0.45.1          | 0.46.0-dev.159 |
  | RC creation       |                 | 0.46.0-rc.0    |
  | development run 160 | 0.46.0-rc.0     | 0.47.0-dev.1   |

- Update [BRANCHING_STRATEGY.md](docs/BRANCHING_STRATEGY.md) to reflect the new post-RC development versioning behavior
- Add BATS test suite covering release lifecycle
