### PR TITLE
feat: support multiple development branches

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.5.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.6.0
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -79,6 +79,14 @@ on:
         type: string
         description: Operate within versions matched regex
         default: '[0-9]+\.[0-9]+'
+      primary-branch-pattern:
+        type: string
+        description: Regex pattern for the primary branch. Matching branch uses development flow
+        default: '^development$'
+      release-branch-pattern:
+        type: string
+        description: Regex pattern for release branches. Branch name must end with X.Y to extract release line
+        default: '^release-[0-9]+\.[0-9]+$'
 
 jobs:
   test:
@@ -107,6 +115,8 @@ jobs:
         with:
           promote: ${{ inputs.promote }}
           filter-version: ${{ inputs.filter-version }}
+          primary-branch-pattern: ${{ inputs.primary-branch-pattern }}
+          release-branch-pattern: ${{ inputs.release-branch-pattern }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -75,6 +75,10 @@ on:
         type: string
         description: Docker build platforms
         default: "linux/amd64"
+      filter-version:
+        type: string
+        description: Operate within versions matched regex
+        default: '[0-9]+\.[0-9]+'
 
 jobs:
   test:
@@ -102,6 +106,7 @@ jobs:
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
+          filter-version: ${{ inputs.filter-version }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -110,7 +110,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -153,7 +153,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -161,7 +161,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
         env:
           IMAGE_NAME: ${{ github.repository }}
 
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -91,6 +91,10 @@ on:
         type: string
         description: Docker build platforms
         default: "linux/amd64"
+      filter-version:
+        type: string
+        description: Operate within versions matched regex
+        default: '[0-9]+\.[0-9]+'
 
 jobs:
   test:
@@ -143,6 +147,7 @@ jobs:
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
+          filter-version: ${{ inputs.filter-version }}
 
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -95,6 +95,14 @@ on:
         type: string
         description: Operate within versions matched regex
         default: '[0-9]+\.[0-9]+'
+      primary-branch-pattern:
+        type: string
+        description: Regex pattern for the primary branch. Matching branch uses development flow
+        default: '^development$'
+      release-branch-pattern:
+        type: string
+        description: Regex pattern for release branches. Branch name must end with X.Y to extract release line
+        default: '^release-[0-9]+\.[0-9]+$'
 
 jobs:
   test:
@@ -148,6 +156,8 @@ jobs:
         with:
           promote: ${{ inputs.promote }}
           filter-version: ${{ inputs.filter-version }}
+          primary-branch-pattern: ${{ inputs.primary-branch-pattern }}
+          release-branch-pattern: ${{ inputs.release-branch-pattern }}
 
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -151,7 +151,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -195,7 +195,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -203,7 +203,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -211,7 +211,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -234,7 +234,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -150,7 +150,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -150,7 +150,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -194,7 +194,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -202,7 +202,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -213,7 +213,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -286,7 +286,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -111,6 +111,14 @@ on:
         type: string
         description: Operate within versions matched regex
         default: '[0-9]+\.[0-9]+'
+      primary-branch-pattern:
+        type: string
+        description: Regex pattern for the primary branch. Matching branch uses development flow
+        default: '^development$'
+      release-branch-pattern:
+        type: string
+        description: Regex pattern for release branches. Branch name must end with X.Y to extract release line
+        default: '^release-[0-9]+\.[0-9]+$'
 
 jobs:
   test:
@@ -147,6 +155,8 @@ jobs:
         with:
           promote: ${{ inputs.promote }}
           filter-version: ${{ inputs.filter-version }}
+          primary-branch-pattern: ${{ inputs.primary-branch-pattern }}
+          release-branch-pattern: ${{ inputs.release-branch-pattern }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -107,6 +107,10 @@ on:
         type: string
         description: Path to the Dockerfile
         default: "Dockerfile"
+      filter-version:
+        type: string
+        description: Operate within versions matched regex
+        default: '[0-9]+\.[0-9]+'
 
 jobs:
   test:
@@ -142,6 +146,7 @@ jobs:
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
+          filter-version: ${{ inputs.filter-version }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -95,6 +95,14 @@ on:
         type: string
         description: Operate within versions matched regex
         default: '[0-9]+\.[0-9]+'
+      primary-branch-pattern:
+        type: string
+        description: Regex pattern for the primary branch. Matching branch uses development flow
+        default: '^development$'
+      release-branch-pattern:
+        type: string
+        description: Regex pattern for release branches. Branch name must end with X.Y to extract release line
+        default: '^release-[0-9]+\.[0-9]+$'
 
 jobs:
   test:
@@ -129,6 +137,8 @@ jobs:
         with:
           promote: ${{ inputs.promote }}
           filter-version: ${{ inputs.filter-version }}
+          primary-branch-pattern: ${{ inputs.primary-branch-pattern }}
+          release-branch-pattern: ${{ inputs.release-branch-pattern }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -132,7 +132,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -175,7 +175,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.5.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -208,7 +208,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -91,6 +91,10 @@ on:
         type: string
         description: Docker build platforms
         default: "linux/amd64"
+      filter-version:
+        type: string
+        description: Operate within versions matched regex
+        default: '[0-9]+\.[0-9]+'
 
 jobs:
   test:
@@ -124,6 +128,7 @@ jobs:
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
+          filter-version: ${{ inputs.filter-version }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -87,6 +87,10 @@ on:
         type: string
         description: Overrides jobs runs-on settings (json-encoded list)
         default: '["ubuntu-24.04"]'
+      filter-version:
+        type: string
+        description: Operate within versions matched regex
+        default: '[0-9]+\.[0-9]+'
 
 jobs:
   test:
@@ -124,6 +128,7 @@ jobs:
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
+          filter-version: ${{ inputs.filter-version }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -91,6 +91,14 @@ on:
         type: string
         description: Operate within versions matched regex
         default: '[0-9]+\.[0-9]+'
+      primary-branch-pattern:
+        type: string
+        description: Regex pattern for the primary branch. Matching branch uses development flow
+        default: '^development$'
+      release-branch-pattern:
+        type: string
+        description: Regex pattern for release branches. Branch name must end with X.Y to extract release line
+        default: '^release-[0-9]+\.[0-9]+$'
 
 jobs:
   test:
@@ -129,6 +137,8 @@ jobs:
         with:
           promote: ${{ inputs.promote }}
           filter-version: ${{ inputs.filter-version }}
+          primary-branch-pattern: ${{ inputs.primary-branch-pattern }}
+          release-branch-pattern: ${{ inputs.release-branch-pattern }}
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     permissions:

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -132,7 +132,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.5.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -149,7 +149,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.5.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -157,7 +157,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -172,7 +172,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.5.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.5.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -3,6 +3,9 @@ name: Calculate Version
 description: Calculate semver-format version based on current branch name and existing tags in git repository
 
 inputs:
+  filter-version:
+    description: Operate within versions matched regex
+    default: '[0-9]+\.[0-9]+'
   promote:
     description: When "true", skips RC increment and produces stable X.Y.Z tag instead. Works only on `release-*` branches
     default: "false"
@@ -87,15 +90,20 @@ runs:
 
         git fetch --tags
 
-        LATEST_STABLE_TAG=$(git tag | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1 || true)
-        LATEST_RC_TAG=$(git tag | grep -E "^[0-9]+\.[0-9]+\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
+        if [ -z "${INPUT_FILTER_VERSION}" ]; then
+          INPUT_FILTER_VERSION="[0-9]\.[0-9]+"
+        fi
+        LATEST_STABLE_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.[0-9]+$" | sort -V | tail -1 || true)
+        LATEST_STABLE_TAG_WITHOUT_FILTER=$(git tag | grep -E "^[0-9]\.[0-9]\.[0-9]+$" | sort -V | tail -1 || true)
+        LATEST_RC_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
 
-        if [[ "${CURRENT_BRANCH}" == "development" ]]; then
+        if [[ "${CURRENT_BRANCH}" == "development" || "${CURRENT_BRANCH}" =~ ^development- ]]; then
           # Determine which is greater: latest stable tag or latest RC tag
           # If latest stable tag is greater, next version is minor bump of given stable with dev suffix added
           # If latest RC tag is greater, next version is given RC line with dev suffix added
           # If no tags found, next version is 0.1.0 with dev suffix added
           # dev suffix is `-dev.N` where N is commit count from the tag that determines the version base
+          # If branch line is greater than stable tag line or RC tag line then calculate next version based on branch line
 
           LATEST_STABLE_LINE=""
           if [[ -n "${LATEST_STABLE_TAG}" ]]; then
@@ -105,10 +113,18 @@ runs:
           if [[ -n "${LATEST_RC_TAG}" ]]; then
             LATEST_RC_LINE=$(echo "${LATEST_RC_TAG}" | grep -oE "^[0-9]+\.[0-9]+")
           fi
+          if [[ $CURRENT_BRANCH =~ ^development- ]]; then
+            BRANCH_LINE="$(echo "${CURRENT_BRANCH##development-}" | awk -F. '{print $1}')"
+            INITIAL_BRANCH_VERSION="${BRANCH_LINE}.0.0"
+          else
+            INITIAL_BRANCH_VERSION="0.0.0"
+          fi
 
           DEV_SOURCE=""  # "stable", "rc", or ""
           if [[ -n "${LATEST_STABLE_LINE}" && -n "${LATEST_RC_LINE}" ]]; then
-            if [ "$(version "${LATEST_STABLE_LINE}.0")" -ge "$(version "${LATEST_RC_LINE}.0")" ]; then
+            if [[ "$(version "${LATEST_STABLE_LINE}.0")" -lt "$(version "${INITIAL_BRANCH_VERSION}")" && "$(version "${LATEST_RC_LINE}.0")" -lt "$(version "${INITIAL_BRANCH_VERSION}")" ]]; then
+              DEV_SOURCE="branch"
+            elif [[ "$(version "${LATEST_STABLE_LINE}.0")" -ge "$(version "${LATEST_RC_LINE}.0")" ]]; then
               DEV_SOURCE="stable"
             else
               DEV_SOURCE="rc"
@@ -130,6 +146,23 @@ runs:
               CURRENT_VERSION="${LATEST_RC_TAG}"
               NEXT_VERSION=$(bump_version "${LATEST_RC_LINE}.0" --minor --pre-release "-dev.${DEV_N}")
               ;;
+            branch)
+              if [[ -n "${LATEST_STABLE_TAG}" && -n "$LATEST_RC_TAG" ]]; then
+                if [[ "$(version "${LATEST_STABLE_TAG}")" -gt "$(version "${LATEST_RC_TAG}")" ]]; then
+                  DEV_N=$(git rev-list --count "${LATEST_STABLE_TAG}..HEAD")
+                else
+                  DEV_N=$(git rev-list --count "${LATEST_RC_TAG}..HEAD")
+                fi
+              elif [[ -n "${LATEST_STABLE_TAG}" ]]; then
+                DEV_N=$(git rev-list --count "${LATEST_STABLE_TAG}..HEAD")
+              elif [ -n "${LATEST_RC_TAG}" ]; then
+                DEV_N=$(git rev-list --count "${LATEST_RC_TAG}..HEAD")
+              else
+                DEV_N=$(git rev-list --count HEAD)
+              fi
+              CURRENT_VERSION=""
+              NEXT_VERSION=$(bump_version "${INITIAL_BRANCH_VERSION}" --pre-release "-dev.${DEV_N}")
+              ;;
             *)
               DEV_N=$(git rev-list --count HEAD)
               CURRENT_VERSION=""
@@ -146,7 +179,7 @@ runs:
             CURRENT_VERSION="${STABLE_TAG}"
             NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" --patch)
             IS_RELEASE="true"
-            if [ "$(version "${NEXT_VERSION}")" -gt "$(version "${LATEST_STABLE_TAG}")" ]; then
+            if [ "$(version "${NEXT_VERSION}")" -gt "$(version "${LATEST_STABLE_TAG_WITHOUT_FILTER}")" ]; then
               IS_LATEST="true"
             fi
 
@@ -156,7 +189,7 @@ runs:
             NEXT_VERSION="${RELEASE_LINE}.0"
             CHANGELOG_MODE="merge-base"
             IS_RELEASE="true"
-            if [ "$(version "${NEXT_VERSION}")" -gt "$(version "${LATEST_STABLE_TAG}")" ]; then
+            if [ "$(version "${NEXT_VERSION}")" -gt "$(version "${LATEST_STABLE_TAG_WITHOUT_FILTER}")" ]; then
               IS_LATEST="true"
             fi
 
@@ -177,7 +210,7 @@ runs:
           fi
 
         else
-          echo "::error::Unsupported branch name '${CURRENT_BRANCH}'. Only 'development' and 'release-X.Y' branches are supported"
+          echo "::error::Unsupported branch name '${CURRENT_BRANCH}'. Only 'development', 'development-X.Y' and 'release-X.Y' branches are supported"
           exit 2
         fi
 
@@ -221,4 +254,5 @@ runs:
         echo "release-line=${RELEASE_LINE:-}" >>$GITHUB_OUTPUT
         echo "changelog-mode=${CHANGELOG_MODE}" >>$GITHUB_OUTPUT
       env:
+        INPUT_FILTER_VERSION: ${{ inputs.filter-version }}
         INPUT_PROMOTE: ${{ inputs.promote }}

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -54,8 +54,9 @@ runs:
         set -euo pipefail
         # set -x
 
-        function version_gt { test "$1" != "$2" && test "$(echo $@ | tr ' ' '\n' | sort -V | tail -1)" == "$1"; }
-        function version_lt { test "$1" != "$2" && test "$(echo $@ | tr ' ' '\n' | sort -V | tail -1)" == "$2"; }
+        function latest_semver { echo "$@" | tr ' ' '\n' | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | tail -1; }
+        function version_gt { test "$1" != "$2" && test "$(latest_semver "$@")" == "$1"; }
+        function version_lt { test "$1" != "$2" && test "$(latest_semver "$@")" == "$2"; }
         function version_ge { test "$1" == "$2" || version_gt "$1" "$2"; }
         function version_le { test "$1" == "$2" || version_lt "$1" "$2"; }
 
@@ -185,7 +186,7 @@ runs:
             CURRENT_VERSION="${STABLE_TAG}"
             NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" --patch)
             IS_RELEASE="true"
-            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
+            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}" || test -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
               IS_LATEST="true"
             fi
 
@@ -195,7 +196,7 @@ runs:
             NEXT_VERSION="${RELEASE_LINE}.0"
             CHANGELOG_MODE="merge-base"
             IS_RELEASE="true"
-            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
+            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}" || test -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
               IS_LATEST="true"
             fi
 

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -91,7 +91,7 @@ runs:
         git fetch --tags
 
         if [ -z "${INPUT_FILTER_VERSION}" ]; then
-          INPUT_FILTER_VERSION="[0-9]\.[0-9]+"
+          INPUT_FILTER_VERSION="[0-9]+\.[0-9]+"
         fi
         LATEST_STABLE_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.[0-9]+$" | sort -V | tail -1 || true)
         LATEST_STABLE_TAG_WITHOUT_FILTER=$(git tag | grep -E "^[0-9]\.[0-9]\.[0-9]+$" | sort -V | tail -1 || true)

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -51,9 +51,13 @@ runs:
       shell: bash
       run: |
         #!/bin/bash
+        set -euo pipefail
         # set -x
 
-        function version { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
+        function version_gt { test "$1" != "$2" && test "$(echo $@ | tr ' ' '\n' | sort -V | tail -1)" == "$1"; }
+        function version_lt { test "$1" != "$2" && test "$(echo $@ | tr ' ' '\n' | sort -V | tail -1)" == "$2"; }
+        function version_ge { test "$1" == "$2" || version_gt "$1" "$2"; }
+        function version_le { test "$1" == "$2" || version_lt "$1" "$2"; }
 
         function bump_version {
           local VERSION
@@ -87,6 +91,8 @@ runs:
         IS_RELEASE="false"
         IS_LATEST="false"
         CHANGELOG_MODE="tag"
+        RELEASE_LINE=""
+        DEV_SOURCE=""
 
         git fetch --tags
 
@@ -122,9 +128,9 @@ runs:
 
           DEV_SOURCE=""  # "stable", "rc", or ""
           if [[ -n "${LATEST_STABLE_LINE}" && -n "${LATEST_RC_LINE}" ]]; then
-            if [[ "$(version "${LATEST_STABLE_LINE}.0")" -lt "$(version "${INITIAL_BRANCH_VERSION}")" && "$(version "${LATEST_RC_LINE}.0")" -lt "$(version "${INITIAL_BRANCH_VERSION}")" ]]; then
+            if version_lt "${LATEST_STABLE_LINE}.0" "${INITIAL_BRANCH_VERSION}" && version_lt "${LATEST_RC_LINE}.0" "${INITIAL_BRANCH_VERSION}"; then
               DEV_SOURCE="branch"
-            elif [[ "$(version "${LATEST_STABLE_LINE}.0")" -ge "$(version "${LATEST_RC_LINE}.0")" ]]; then
+            elif version_ge "${LATEST_STABLE_LINE}.0" "${LATEST_RC_LINE}.0"; then
               DEV_SOURCE="stable"
             else
               DEV_SOURCE="rc"
@@ -147,8 +153,8 @@ runs:
               NEXT_VERSION=$(bump_version "${LATEST_RC_LINE}.0" --minor --pre-release "-dev.${DEV_N}")
               ;;
             branch)
-              if [[ -n "${LATEST_STABLE_TAG}" && -n "$LATEST_RC_TAG" ]]; then
-                if [[ "$(version "${LATEST_STABLE_TAG}")" -gt "$(version "${LATEST_RC_TAG}")" ]]; then
+              if [[ -n "${LATEST_STABLE_TAG}" && -n "${LATEST_RC_TAG}" ]]; then
+                if version_gt "${LATEST_STABLE_TAG}" "${LATEST_RC_TAG}"; then
                   DEV_N=$(git rev-list --count "${LATEST_STABLE_TAG}..HEAD")
                 else
                   DEV_N=$(git rev-list --count "${LATEST_RC_TAG}..HEAD")
@@ -179,7 +185,7 @@ runs:
             CURRENT_VERSION="${STABLE_TAG}"
             NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" --patch)
             IS_RELEASE="true"
-            if [ "$(version "${NEXT_VERSION}")" -gt "$(version "${LATEST_STABLE_TAG_WITHOUT_FILTER}")" ]; then
+            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
               IS_LATEST="true"
             fi
 
@@ -189,7 +195,7 @@ runs:
             NEXT_VERSION="${RELEASE_LINE}.0"
             CHANGELOG_MODE="merge-base"
             IS_RELEASE="true"
-            if [ "$(version "${NEXT_VERSION}")" -gt "$(version "${LATEST_STABLE_TAG_WITHOUT_FILTER}")" ]; then
+            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
               IS_LATEST="true"
             fi
 
@@ -199,7 +205,7 @@ runs:
             LATEST_RC=$(git tag | grep -E "^${RELEASE_LINE}\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
 
             if [[ -n "${LATEST_RC}" ]]; then
-              RC_N=$(echo "${LATEST_RC}" | sed "s/^.*-rc\.//")
+              RC_N=${LATEST_RC/#*-rc\./}
               CURRENT_VERSION="${LATEST_RC}"
               NEXT_VERSION=$(bump_version "${RELEASE_LINE}.0" --pre-release "-rc.$((RC_N + 1))")
 
@@ -244,15 +250,17 @@ runs:
         echo "$OUTPUTS_SUMMARY" >>"$GITHUB_STEP_SUMMARY"
 
         # Outputs
-        echo "current-version=${CURRENT_VERSION}" >>$GITHUB_OUTPUT
-        echo "next-version=${NEXT_VERSION}" >>$GITHUB_OUTPUT
-        echo "next-version-without-hyphens=${NEXT_VERSION_WITHOUT_HYPHENS}" >>$GITHUB_OUTPUT
-        echo "latest-stable-tag=${LATEST_STABLE_TAG}" >>$GITHUB_OUTPUT
-        echo "is-release-candidate=${IS_RELEASE_CANDIDATE}" >>$GITHUB_OUTPUT
-        echo "is-release=${IS_RELEASE}" >>$GITHUB_OUTPUT
-        echo "is-latest=${IS_LATEST}" >>$GITHUB_OUTPUT
-        echo "release-line=${RELEASE_LINE:-}" >>$GITHUB_OUTPUT
-        echo "changelog-mode=${CHANGELOG_MODE}" >>$GITHUB_OUTPUT
+        cat <<EOF >>"${GITHUB_OUTPUT}"
+        current-version=${CURRENT_VERSION}
+        next-version=${NEXT_VERSION}
+        next-version-without-hyphens=${NEXT_VERSION_WITHOUT_HYPHENS}
+        latest-stable-tag=${LATEST_STABLE_TAG}
+        is-release-candidate=${IS_RELEASE_CANDIDATE}
+        is-release=${IS_RELEASE}
+        is-latest=${IS_LATEST}
+        release-line=${RELEASE_LINE}
+        changelog-mode=${CHANGELOG_MODE}
+        EOF
       env:
         INPUT_FILTER_VERSION: ${{ inputs.filter-version }}
         INPUT_PROMOTE: ${{ inputs.promote }}

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -94,7 +94,7 @@ runs:
           INPUT_FILTER_VERSION="[0-9]+\.[0-9]+"
         fi
         LATEST_STABLE_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.[0-9]+$" | sort -V | tail -1 || true)
-        LATEST_STABLE_TAG_WITHOUT_FILTER=$(git tag | grep -E "^[0-9]\.[0-9]\.[0-9]+$" | sort -V | tail -1 || true)
+        LATEST_STABLE_TAG_WITHOUT_FILTER=$(git tag | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1 || true)
         LATEST_RC_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
 
         if [[ "${CURRENT_BRANCH}" == "development" || "${CURRENT_BRANCH}" =~ ^development- ]]; then

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -9,6 +9,12 @@ inputs:
   promote:
     description: When "true", skips RC increment and produces stable X.Y.Z tag instead. Works only on `release-*` branches
     default: "false"
+  primary-branch-pattern:
+    description: Regex pattern for the primary branch. Matching branch uses development flow
+    default: '^development$'
+  release-branch-pattern:
+    description: Regex pattern for release branches. Branch name must end with X.Y to extract release line
+    default: '^release-[0-9]+\.[0-9]+$'
 
 outputs:
   current-version:
@@ -46,6 +52,10 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
+    - name: Install Tools
+      run: |
+        npm install -g semver
+      shell: bash
     - name: Calculate Version
       id: calculate-version
       shell: bash
@@ -54,38 +64,11 @@ runs:
         set -euo pipefail
         # set -x
 
-        function latest_semver { echo "$@" | tr ' ' '\n' | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | tail -1; }
-        function version_gt { test "$1" != "$2" && test "$(latest_semver "$@")" == "$1"; }
-        function version_lt { test "$1" != "$2" && test "$(latest_semver "$@")" == "$2"; }
-        function version_ge { test "$1" == "$2" || version_gt "$1" "$2"; }
-        function version_le { test "$1" == "$2" || version_lt "$1" "$2"; }
-
-        function bump_version {
-          local VERSION
-          IFS='.' read -r -a VERSION <<<"${1}"
-          shift
-
-          # Split the version string into Major, Minor and Patch numbers
-          local MAJOR=${VERSION[0]:-0}
-          local MINOR=${VERSION[1]:-0}
-          local PATCH=${VERSION[2]:-0}
-          local PRE_RELEASE=""
-
-          while [[ $# -gt 0 ]]; do
-            case "$1" in
-              --minor) MINOR=$((MINOR + 1)); PATCH=0; shift ;;
-              --patch) PATCH=$((PATCH + 1)); shift ;;
-              --pre-release) PRE_RELEASE="$2"; shift 2 ;;
-              *) shift ;;
-            esac
-          done
-
-          echo "${MAJOR}.${MINOR}.${PATCH}${PRE_RELEASE}"
-        }
-
         CURRENT_BRANCH=$(git symbolic-ref -q HEAD || true)
         CURRENT_BRANCH=${CURRENT_BRANCH##refs/heads/}
         CURRENT_BRANCH=${CURRENT_BRANCH:-HEAD}
+        PRIMARY_BRANCH_PATTERN="${INPUT_PRIMARY_BRANCH_PATTERN:-^development$}"
+        RELEASE_BRANCH_PATTERN="${INPUT_RELEASE_BRANCH_PATTERN:-^release-[0-9]+\.[0-9]+$}"
 
         PROMOTE="${INPUT_PROMOTE}"
         IS_RELEASE_CANDIDATE="false"
@@ -104,7 +87,7 @@ runs:
         LATEST_STABLE_TAG_WITHOUT_FILTER=$(git tag | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1 || true)
         LATEST_RC_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
 
-        if [[ "${CURRENT_BRANCH}" == "development" || "${CURRENT_BRANCH}" =~ ^development- ]]; then
+        if [[ "${CURRENT_BRANCH}" =~ ${PRIMARY_BRANCH_PATTERN} ]]; then
           # Determine which is greater: latest stable tag or latest RC tag
           # If latest stable tag is greater, next version is minor bump of given stable with dev suffix added
           # If latest RC tag is greater, next version is given RC line with dev suffix added
@@ -129,9 +112,9 @@ runs:
 
           DEV_SOURCE=""  # "stable", "rc", or ""
           if [[ -n "${LATEST_STABLE_LINE}" && -n "${LATEST_RC_LINE}" ]]; then
-            if version_lt "${LATEST_STABLE_LINE}.0" "${INITIAL_BRANCH_VERSION}" && version_lt "${LATEST_RC_LINE}.0" "${INITIAL_BRANCH_VERSION}"; then
+            if semver "${LATEST_STABLE_LINE}.0" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1 && semver "${LATEST_RC_LINE}.0" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1; then
               DEV_SOURCE="branch"
-            elif version_ge "${LATEST_STABLE_LINE}.0" "${LATEST_RC_LINE}.0"; then
+            elif semver "${LATEST_STABLE_LINE}.0" --range ">=${LATEST_RC_LINE}.0" >/dev/null 2>&1; then
               DEV_SOURCE="stable"
             else
               DEV_SOURCE="rc"
@@ -146,16 +129,16 @@ runs:
             stable)
               DEV_N=$(git rev-list --count "${LATEST_STABLE_TAG}..HEAD")
               CURRENT_VERSION="${LATEST_STABLE_TAG}"
-              NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" --minor --pre-release "-dev.${DEV_N}")
+              NEXT_VERSION="$(semver "${CURRENT_VERSION}" --increment minor)-dev.${DEV_N}"
               ;;
             rc)
               DEV_N=$(git rev-list --count "${LATEST_RC_TAG}..HEAD")
               CURRENT_VERSION="${LATEST_RC_TAG}"
-              NEXT_VERSION=$(bump_version "${LATEST_RC_LINE}.0" --minor --pre-release "-dev.${DEV_N}")
+              NEXT_VERSION="$(semver "${LATEST_RC_LINE}.0" --increment minor)-dev.${DEV_N}"
               ;;
             branch)
               if [[ -n "${LATEST_STABLE_TAG}" && -n "${LATEST_RC_TAG}" ]]; then
-                if version_gt "${LATEST_STABLE_TAG}" "${LATEST_RC_TAG}"; then
+                if semver "${LATEST_STABLE_TAG}" --range ">${LATEST_RC_TAG}" >/dev/null 2>&1; then
                   DEV_N=$(git rev-list --count "${LATEST_STABLE_TAG}..HEAD")
                 else
                   DEV_N=$(git rev-list --count "${LATEST_RC_TAG}..HEAD")
@@ -168,25 +151,30 @@ runs:
                 DEV_N=$(git rev-list --count HEAD)
               fi
               CURRENT_VERSION=""
-              NEXT_VERSION=$(bump_version "${INITIAL_BRANCH_VERSION}" --pre-release "-dev.${DEV_N}")
+              NEXT_VERSION="${INITIAL_BRANCH_VERSION}-dev.${DEV_N}"
               ;;
             *)
               DEV_N=$(git rev-list --count HEAD)
               CURRENT_VERSION=""
-              NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" --minor --pre-release "-dev.${DEV_N}")
+              NEXT_VERSION="$(semver "0.0.0" --increment minor)-dev.${DEV_N}"
               ;;
           esac
 
-        elif [[ "${CURRENT_BRANCH}" =~ ^release- ]]; then
-          RELEASE_LINE="${CURRENT_BRANCH##release-}" # e.g. "1.0"
+        elif [[ "${CURRENT_BRANCH}" =~ ${RELEASE_BRANCH_PATTERN} ]]; then
+          RELEASE_LINE=$(echo "${CURRENT_BRANCH}" | grep -oE '[0-9]+\.[0-9]+$' || true)
+          if [[ -z "${RELEASE_LINE}" ]]; then
+            echo "::error::Can't extract valid {MAJOR.MINOR} version from release branch name '${CURRENT_BRANCH}'. Expected branch name ending with X.Y (for example: release-1.0)"
+            exit 2
+          fi
+
           STABLE_TAG=$(git tag | grep -E "^${RELEASE_LINE}\.[0-9]+$" | sort -V | tail -1 || true)
 
           if [[ -n "${STABLE_TAG}" ]]; then
             # Stable tag found = at least one release on this release line --> bump patch version
             CURRENT_VERSION="${STABLE_TAG}"
-            NEXT_VERSION=$(bump_version "${CURRENT_VERSION}" --patch)
+            NEXT_VERSION=$(semver "${CURRENT_VERSION}" --increment patch)
             IS_RELEASE="true"
-            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}" || test -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
+            if [[ -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] || semver "${NEXT_VERSION}" --range ">${LATEST_STABLE_TAG_WITHOUT_FILTER}" >/dev/null 2>&1; then
               IS_LATEST="true"
             fi
 
@@ -196,7 +184,7 @@ runs:
             NEXT_VERSION="${RELEASE_LINE}.0"
             CHANGELOG_MODE="merge-base"
             IS_RELEASE="true"
-            if version_gt "${NEXT_VERSION}" "${LATEST_STABLE_TAG_WITHOUT_FILTER}" || test -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
+            if [[ -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] || semver "${NEXT_VERSION}" --range ">${LATEST_STABLE_TAG_WITHOUT_FILTER}" >/dev/null 2>&1; then
               IS_LATEST="true"
             fi
 
@@ -206,18 +194,17 @@ runs:
             LATEST_RC=$(git tag | grep -E "^${RELEASE_LINE}\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
 
             if [[ -n "${LATEST_RC}" ]]; then
-              RC_N=${LATEST_RC/#*-rc\./}
               CURRENT_VERSION="${LATEST_RC}"
-              NEXT_VERSION=$(bump_version "${RELEASE_LINE}.0" --pre-release "-rc.$((RC_N + 1))")
+              NEXT_VERSION=$(semver "${LATEST_RC}" --increment prerelease --preid rc)
 
             else
               CURRENT_VERSION=""
-              NEXT_VERSION=$(bump_version "${RELEASE_LINE}.0" --pre-release "-rc.0")
+              NEXT_VERSION="${RELEASE_LINE}.0-rc.0"
             fi
           fi
 
         else
-          echo "::error::Unsupported branch name '${CURRENT_BRANCH}'. Only 'development', 'development-X.Y' and 'release-X.Y' branches are supported"
+          echo "::error::Unsupported branch name '${CURRENT_BRANCH}'. Provided branch must match '${PRIMARY_BRANCH_PATTERN}' or '${RELEASE_BRANCH_PATTERN}' patterns"
           exit 2
         fi
 
@@ -265,3 +252,5 @@ runs:
       env:
         INPUT_FILTER_VERSION: ${{ inputs.filter-version }}
         INPUT_PROMOTE: ${{ inputs.promote }}
+        INPUT_PRIMARY_BRANCH_PATTERN: ${{ inputs.primary-branch-pattern }}
+        INPUT_RELEASE_BRANCH_PATTERN: ${{ inputs.release-branch-pattern }}

--- a/test/semantic_versioning.bats
+++ b/test/semantic_versioning.bats
@@ -51,8 +51,10 @@ read_output_key() {
 }
 
 run_calc() {
-  local promote="${1}"
-  local filter_version="${2}"
+  local filter_version="${1:-[0-9]+\.[0-9]+}"
+  local promote="${2}"
+  local primary_branch_pattern="${3:-^development$}"
+  local release_branch_pattern="${4:-^release-[0-9]+\.[0-9]+$}"
 
   local GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/calc_output.txt"
   local GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/calc_summary.md"
@@ -60,8 +62,10 @@ run_calc() {
   : >"${GITHUB_OUTPUT}"
   : >"${GITHUB_STEP_SUMMARY}"
 
-  INPUT_PROMOTE="${promote}" \
   INPUT_FILTER_VERSION="${filter_version}" \
+  INPUT_PROMOTE="${promote}" \
+  INPUT_PRIMARY_BRANCH_PATTERN="${primary_branch_pattern}" \
+  INPUT_RELEASE_BRANCH_PATTERN="${release_branch_pattern}" \
   GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
   GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY}" \
   run bash "${ACTION_RUN_SCRIPT}"
@@ -83,17 +87,24 @@ run_calc() {
 assert_calc() {
   local scenario="${1}"
   local branch="${2}"
-  local promote="${3}"
-  local expected_next="${4}"
-  local expected_is_rc="${5}"
-  local expected_is_release="${6}"
-  local expected_is_latest="${7}"
-  local expected_release_line="${8}"
-  local expected_changelog_mode="${9}"
-  local filter_version="${10}"
+  local filter_version="${3}"
+  local promote="${4}"
+  local primary_branch_pattern="${5}"
+  local release_branch_pattern="${6}"
+  local expected_next="${7}"
+  local expected_is_rc="${8}"
+  local expected_is_release="${9}"
+  local expected_is_latest="${10}"
+  local expected_release_line="${11}"
+  local expected_changelog_mode="${12}"
+
+  if [ "$#" -ne 12 ]; then
+    echo "FAIL ${scenario}: Invalid assert_calc argument count '$#'" >&3
+    return 1
+  fi
 
   git checkout -q "${branch}"
-  run_calc "${promote}" "${filter_version}"
+  run_calc "${filter_version}" "${promote}" "${primary_branch_pattern}" "${release_branch_pattern}"
 
   # Bats assertions
   [ "${expected_next}" = "${CALC_NEXT_VERSION}" ] || { echo "FAIL ${scenario}: Expected next-version '${expected_next}', got '${CALC_NEXT_VERSION}'" >&3; return 1; }
@@ -109,32 +120,118 @@ assert_calc() {
 #                  TESTS
 # ==========================================
 
-@test "Full lifecycle scenarios (0-16)" {
-  init_dummy_repo "${BATS_TEST_TMPDIR}/full-lifecycle"
+@test "DEV_N calculation" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/devn-calculation"
+
+  local PRIMARY_PATTERN="^development$"
+  local RELEASE_PATTERN="^release-[0-9]+\.[0-9]+$"
+  local FILTER_VERSION="[0-9]+\.[0-9]+"
 
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "false" "0.1.0-dev.1" "false" "false" "false" "" "tag"
-
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "false" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.0
-  assert_calc "S2" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  assert_calc "E1" "release-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.0
+
+  assert_calc "E2" "release-1.0" "${FILTER_VERSION}" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+
+  git checkout -q development
+  commit_msg "feat: 2"
+  assert_calc "E3" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.1
+  assert_calc "E4" "release-1.1" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.0-rc.0
+
+  git checkout -q development
+  commit_msg "fix: edge-after-rc-cut"
+  assert_calc "E5" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+}
+
+@test "Custom branch patterns preserve current primary and release semantics" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/custom-branch-patterns"
+  local FILTER_VERSION="[0-9]+\.[0-9]+"
+
+  commit_msg "chore: initial commit"
+  git checkout -q -b trunk
+
+  run_calc "${FILTER_VERSION}" "false" "^trunk$" "^cut-[0-9]+\.[0-9]+$"
+  [ "0.1.0-dev.1" = "${CALC_NEXT_VERSION}" ]
+  [ "false" = "${CALC_IS_RELEASE_CANDIDATE}" ]
+  [ "false" = "${CALC_IS_RELEASE}" ]
+  [ "false" = "${CALC_IS_LATEST}" ]
+  [ "" = "${CALC_RELEASE_LINE}" ]
+  [ "tag" = "${CALC_CHANGELOG_MODE}" ]
+
+  git checkout -q -b cut-1.0
+  run_calc "${FILTER_VERSION}" "false" "^trunk$" "^cut-[0-9]+\.[0-9]+$"
+  [ "1.0.0-rc.0" = "${CALC_NEXT_VERSION}" ]
+  [ "true" = "${CALC_IS_RELEASE_CANDIDATE}" ]
+  [ "false" = "${CALC_IS_RELEASE}" ]
+  [ "false" = "${CALC_IS_LATEST}" ]
+  [ "1.0" = "${CALC_RELEASE_LINE}" ]
+  [ "tag" = "${CALC_CHANGELOG_MODE}" ]
+}
+
+@test "Invalid release-line capture" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/invalid-release-line-capture"
+
+  commit_msg "chore: initial commit"
+  git checkout -q -b rel-abc
+
+  local GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/calc_output_invalid.txt"
+  local GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/calc_summary_invalid.md"
+
+  : >"${GITHUB_OUTPUT}"
+  : >"${GITHUB_STEP_SUMMARY}"
+
+  INPUT_PROMOTE="false" \
+  INPUT_PRIMARY_BRANCH_PATTERN="^development$" \
+  INPUT_RELEASE_BRANCH_PATTERN="^rel-.+$" \
+  INPUT_FILTER_VERSION="[0-9]+\.[0-9]+" \
+  GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+  GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY}" \
+  run bash "${ACTION_RUN_SCRIPT}"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Expected branch name ending with X.Y"* ]]
+}
+
+@test "Full lifecycle simulation" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/full-lifecycle"
+
+  local PRIMARY_PATTERN="^development$"
+  local RELEASE_PATTERN="^release-[0-9]+\.[0-9]+$"
+  local FILTER_VERSION="[0-9]+\.[0-9]+"
+
+  commit_msg "chore: initial commit"
+  assert_calc "S0" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 1"
+  assert_calc "S1" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.0
+  assert_calc "S2" "release-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0-rc.0
 
   git checkout -q development
   commit_msg "fix: 1"
   local sha_fix1="${LAST_COMMIT_SHA}"
-  assert_calc "S3" "development" "false" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S3" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-1.0
   cherry_pick_commit "${sha_fix1}"
-  assert_calc "S4" "release-1.0" "false" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  assert_calc "S4" "release-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0-rc.1
 
-  assert_calc "S5" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  assert_calc "S5" "release-1.0" "${FILTER_VERSION}" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 
@@ -142,34 +239,34 @@ assert_calc() {
   commit_msg "feat: 2"
   commit_msg "fix: 2"
   local sha_fix2="${LAST_COMMIT_SHA}"
-  assert_calc "S6" "development" "false" "1.1.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S6" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q release-1.0
   cherry_pick_commit "${sha_fix2}"
-  assert_calc "S7" "release-1.0" "false" "1.0.1" "false" "true" "true" "1.0" "tag"
+  assert_calc "S7" "release-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.1" "false" "true" "true" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.1
 
   git checkout -q development
   git checkout -q -b release-1.1
-  assert_calc "S8" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  assert_calc "S8" "release-1.1" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.1.0-rc.0
 
-  assert_calc "S9" "release-1.1" "true" "1.1.0" "false" "true" "true" "1.1" "merge-base"
+  assert_calc "S9" "release-1.1" "${FILTER_VERSION}" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0" "false" "true" "true" "1.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.1.0
 
   git checkout -q development
   commit_msg "feat: 3"
-  assert_calc "S10" "development" "false" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S10" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.2
-  assert_calc "S11" "release-1.2" "false" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
+  assert_calc "S11" "release-1.2" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.2.0-rc.0
 
-  assert_calc "S12" "release-1.2" "true" "1.2.0" "false" "true" "true" "1.2" "merge-base"
+  assert_calc "S12" "release-1.2" "${FILTER_VERSION}" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0" "false" "true" "true" "1.2" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.2.0
 
@@ -180,146 +277,218 @@ assert_calc() {
   local sha_fix4="${LAST_COMMIT_SHA}"
   commit_msg "fix: 5"
   local sha_fix5="${LAST_COMMIT_SHA}"
-  assert_calc "S13" "development" "false" "1.3.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S13" "development" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.3.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q release-1.1
   cherry_pick_commit "${sha_fix3}"
-  assert_calc "S14" "release-1.1" "false" "1.1.1" "false" "true" "false" "1.1" "tag"
+  assert_calc "S14" "release-1.1" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.1" "false" "true" "false" "1.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.1.1
 
   git checkout -q release-1.2
   cherry_pick_commit "${sha_fix4}"
-  assert_calc "S15" "release-1.2" "false" "1.2.1" "false" "true" "true" "1.2" "tag"
+  assert_calc "S15" "release-1.2" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.1" "false" "true" "true" "1.2" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.2.1
 
   git checkout -q release-1.0
   cherry_pick_commit "${sha_fix5}"
-  assert_calc "S16" "release-1.0" "false" "1.0.2" "false" "true" "false" "1.0" "tag"
+  assert_calc "S16" "release-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.2" "false" "true" "false" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.2
 }
 
-@test "DEV_N edge regression suite" {
-  init_dummy_repo "${BATS_TEST_TMPDIR}/devn-edge"
+@test "Full lifecycle simulation with custom branch names" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/full-lifecycle-custom-branches"
+
+  local PRIMARY_PATTERN="^trunk$"
+  local RELEASE_PATTERN="^cut-[0-9]+\.[0-9]+$"
+  local FILTER_VERSION="[0-9]+\.[0-9]+"
+
+  git checkout -q -b trunk
 
   commit_msg "chore: initial commit"
-  commit_msg "feat: 1"
+  assert_calc "CS0" "trunk" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
-  git checkout -q -b release-1.0
-  assert_calc "E1" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  commit_msg "feat: 1"
+  assert_calc "CS1" "trunk" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b cut-1.0
+  assert_calc "CS2" "cut-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0-rc.0
 
-  assert_calc "E2" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  git checkout -q trunk
+  commit_msg "fix: 1"
+  local sha_fix1="${LAST_COMMIT_SHA}"
+  assert_calc "CS3" "trunk" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q cut-1.0
+  cherry_pick_commit "${sha_fix1}"
+  assert_calc "CS4" "cut-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.1
+
+  assert_calc "CS5" "cut-1.0" "${FILTER_VERSION}" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 
-  git checkout -q development
+  git checkout -q trunk
   commit_msg "feat: 2"
-  assert_calc "E3" "development" "false" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+  commit_msg "fix: 2"
+  local sha_fix2="${LAST_COMMIT_SHA}"
+  assert_calc "CS6" "trunk" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.3" "false" "false" "false" "" "tag"
 
-  git checkout -q -b release-1.1
-  assert_calc "E4" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  git checkout -q cut-1.0
+  cherry_pick_commit "${sha_fix2}"
+  assert_calc "CS7" "cut-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.1" "false" "true" "true" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.1
+
+  git checkout -q trunk
+  git checkout -q -b cut-1.1
+  assert_calc "CS8" "cut-1.1" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.1.0-rc.0
 
-  git checkout -q development
-  commit_msg "fix: edge-after-rc-cut"
-  assert_calc "E5" "development" "false" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "CS9" "cut-1.1" "${FILTER_VERSION}" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0" "false" "true" "true" "1.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.0
+
+  git checkout -q trunk
+  commit_msg "feat: 3"
+  assert_calc "CS10" "trunk" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q -b cut-1.2
+  assert_calc "CS11" "cut-1.2" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.2.0-rc.0
+
+  assert_calc "CS12" "cut-1.2" "${FILTER_VERSION}" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0" "false" "true" "true" "1.2" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.2.0
+
+  git checkout -q trunk
+  commit_msg "fix: 3"
+  local sha_fix3="${LAST_COMMIT_SHA}"
+  commit_msg "fix: 4"
+  local sha_fix4="${LAST_COMMIT_SHA}"
+  commit_msg "fix: 5"
+  local sha_fix5="${LAST_COMMIT_SHA}"
+  assert_calc "CS13" "trunk" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.3.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q cut-1.1
+  cherry_pick_commit "${sha_fix3}"
+  assert_calc "CS14" "cut-1.1" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.1" "false" "true" "false" "1.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.1
+
+  git checkout -q cut-1.2
+  cherry_pick_commit "${sha_fix4}"
+  assert_calc "CS15" "cut-1.2" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.1" "false" "true" "true" "1.2" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.2.1
+
+  git checkout -q cut-1.0
+  cherry_pick_commit "${sha_fix5}"
+  assert_calc "CS16" "cut-1.0" "${FILTER_VERSION}" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.2" "false" "true" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.2
 }
 
-@test "Two development branches" {
+@test "Two development branches simultaneously" {
   init_dummy_repo "${BATS_TEST_TMPDIR}/two-dev-branches"
 
+  local PRIMARY_PATTERN="^development$|^development-.+$"
+  local RELEASE_PATTERN="^release-[0-9]+\.[0-9]+$"
+
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "false" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "false" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.1
-  assert_calc "S2" "release-0.1" "false" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0-rc.0
 
   git checkout -q development
   commit_msg "fix: 1"
   sha_fix1="${LAST_COMMIT_SHA}"
-  assert_calc "S3" "development" "false" "0.2.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S3" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-0.1
   cherry_pick_commit "${sha_fix1}"
-  assert_calc "S4" "release-0.1" "false" "0.1.0-rc.1" "true" "false" "false" "0.1" "tag"
+  assert_calc "S4" "release-0.1" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.1" "true" "false" "false" "0.1" "tag"
 
-  assert_calc "S5" "release-0.1" "true" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  assert_calc "S5" "release-0.1" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0" "false" "true" "true" "0.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0
 
   git checkout -q development
   commit_msg "feat: 2"
-  assert_calc "S6" "development" "false" "0.2.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S6" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.2
-  assert_calc "S7" "release-0.2" "false" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag"
+  assert_calc "S7" "release-0.2" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag"
 
-  assert_calc "S8" "release-0.2" "true" "0.2.0" "false" "true" "true" "0.2" "merge-base"
+  assert_calc "S8" "release-0.2" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0" "false" "true" "true" "0.2" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.2.0
 
   git checkout -q development
   commit_msg "fix: 2"
   sha_fix2="${LAST_COMMIT_SHA}"
-  assert_calc "S9" "development" "false" "0.3.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S9" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-0.2
   cherry_pick_commit "${sha_fix2}"
-  assert_calc "S10" "release-0.2" "true" "0.2.1" "false" "true" "true" "0.2" "tag"
+  assert_calc "S10" "release-0.2" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.1" "false" "true" "true" "0.2" "tag"
   git tag 0.2.1
 
   git checkout -q development
   commit_msg "feat: 3"
-  assert_calc "S11" "development" "false" "0.3.0-dev.2" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S11" "development" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b development-1.0
   commit_msg "feat: 4"
-  assert_calc "S12" "development-1.0" "false" "1.0.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S12" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q development
   commit_msg "feat: 5"
   commit_msg "feat: 6"
   commit_msg "feat: 7"
-  assert_calc "S13" "development" "false" "0.3.0-dev.5" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S13" "development" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-dev.5" "false" "false" "false" "" "tag"
 
   git checkout -q development-1.0
   commit_msg "feat: 8"
-  assert_calc "S14" "development-1.0" "false" "1.0.0-dev.4" "false" "false" "false" "" "tag"
+  assert_calc "S14" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.4" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.0
-  assert_calc "S15" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  assert_calc "S15" "release-1.0" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   git tag 1.0.0-rc.0
 
-  assert_calc "S16" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  assert_calc "S16" "release-1.0" "1\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 
   git checkout -q development
   git checkout -q -b release-0.3
-  assert_calc "S17" "release-0.3" "false" "0.3.0-rc.0" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  assert_calc "S17" "release-0.3" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-rc.0" "true" "false" "false" "0.3" "tag"
   git tag 0.3.0-rc.0
 
   git checkout -q development
   commit_msg "fix: 7"
   sha_fix7="${LAST_COMMIT_SHA}"
-  assert_calc "S18" "development" "false" "0.4.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S18" "development" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.4.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-0.3
   cherry_pick_commit "${sha_fix7}"
-  assert_calc "S19" "release-0.3" "false" "0.3.0-rc.1" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  assert_calc "S19" "release-0.3" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-rc.1" "true" "false" "false" "0.3" "tag"
   git tag 0.3.0-rc.1
 
-  assert_calc "S20" "release-0.3" "true" "0.3.0" "false" "true" "false" "0.3" "merge-base" "0\.[0-9]+"
+  assert_calc "S20" "release-0.3" "0\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0" "false" "true" "false" "0.3" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.3.0
 
@@ -327,44 +496,44 @@ assert_calc() {
   commit_msg "fix: 8"
   sha_fix8="${LAST_COMMIT_SHA}"
   commit_msg "feat: 9"
-  assert_calc "S21" "development-1.0" "false" "1.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S21" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.1
-  assert_calc "S22" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  assert_calc "S22" "release-1.1" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
   git tag 1.1.0-rc.0
 
-  assert_calc "S23" "release-1.1" "true" "1.1.0" "false" "true" "true" "1.1" "merge-base"
+  assert_calc "S23" "release-1.1" "1\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0" "false" "true" "true" "1.1" "merge-base"
   git tag 1.1.0
 
   git checkout -q development-1.0
   commit_msg "fix: 9"
   sha_fix9="${LAST_COMMIT_SHA}"
-  assert_calc "S24" "development-1.0" "false" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S24" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-1.0
   cherry_pick_commit "${sha_fix9}"
-  assert_calc "S25" "release-1.0" "false" "1.0.1" "false" "true" "false" "1.0" "tag"
+  assert_calc "S25" "release-1.0" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.1" "false" "true" "false" "1.0" "tag"
   git tag 1.0.1
 
   git checkout -q release-1.1
   cherry_pick_commit "${sha_fix9}"
-  assert_calc "S26" "release-1.1" "false" "1.1.1" "false" "true" "true" "1.1" "tag"
+  assert_calc "S26" "release-1.1" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.1" "false" "true" "true" "1.1" "tag"
   git tag 1.1.1
 
   git checkout -q development-1.0
   commit_msg "feat: 10"
   commit_msg "feat: 11"
-  assert_calc "S27" "development-1.0" "false" "1.2.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S27" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q development
   commit_msg "feat: 12"
-  assert_calc "S28" "development" "false" "0.4.0-dev.2" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S28" "development" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.4.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.4
-  assert_calc "S29" "release-0.4" "false" "0.4.0-rc.0" "true" "false" "false" "0.4" "tag" "0\.[0-9]+"
+  assert_calc "S29" "release-0.4" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.4.0-rc.0" "true" "false" "false" "0.4" "tag"
   git tag 0.4.0-rc.0
 
-  assert_calc "S30" "release-0.4" "true" "0.4.0" "false" "true" "false" "0.4" "merge-base" "0\.[0-9]+"
+  assert_calc "S30" "release-0.4" "0\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.4.0" "false" "true" "false" "0.4" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.4.0
 
@@ -372,14 +541,14 @@ assert_calc() {
   commit_msg "feat: 13"
   commit_msg "fix: 11"
   sha_fix11="${LAST_COMMIT_SHA}"
-  assert_calc "S31" "development-1.0" "false" "1.2.0-dev.5" "false" "false" "false" "" "tag"
+  assert_calc "S31" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.5" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.2
-  assert_calc "S32" "release-1.2" "false" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
+  assert_calc "S32" "release-1.2" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
   git tag 1.2.0-rc.0
 
   git checkout -q release-1.2
-  assert_calc "S33" "release-1.2" "true" "1.2.0" "false" "true" "true" "1.2" "merge-base"
+  assert_calc "S33" "release-1.2" "1\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0" "false" "true" "true" "1.2" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.2.0
 }
@@ -387,43 +556,46 @@ assert_calc() {
 @test "Swap development branches" {
   init_dummy_repo "${BATS_TEST_TMPDIR}/swap-dev-branches"
 
+  local PRIMARY_PATTERN="^development$|^development-.+$"
+  local RELEASE_PATTERN="^release-[0-9]+\.[0-9]+$"
+
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "false" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "false" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.1
-  assert_calc "S2" "release-0.1" "false" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0-rc.0
 
-  assert_calc "S3" "release-0.1" "true" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0" "false" "true" "true" "0.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0
 
   git checkout -q development
   commit_msg "ci: filter 0.x versions"
-  assert_calc "S4" "development" "false" "0.2.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S4" "development" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q -b development-1.x
   commit_msg "feat: 3"
-  assert_calc "S5" "development-1.x" "false" "1.0.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S5" "development-1.x" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.0
-  assert_calc "S6" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  assert_calc "S6" "release-1.0" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   git tag 1.0.0-rc.0
 
-  assert_calc "S7" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  assert_calc "S7" "release-1.0" "1\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 
   git checkout -q development
   git checkout -q -b release-0.2
-  assert_calc "S8" "release-0.2" "false" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag" "0\.[0-9]+"
+  assert_calc "S8" "release-0.2" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag"
   git tag 0.2.0-rc.0
 
-  assert_calc "S9" "release-0.2" "true" "0.2.0" "false" "true" "false" "0.2" "merge-base" "0\.[0-9]+"
+  assert_calc "S9" "release-0.2" "0\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0" "false" "true" "false" "0.2" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.2.0
 
@@ -431,50 +603,50 @@ assert_calc() {
   git branch -q -m development-1.x development
   git checkout -q development
   commit_msg "feat: 4"
-  assert_calc "S10" "development" "false" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S10" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q development-0.x
   commit_msg "feat: 5"
-  assert_calc "S11" "development-0.x" "false" "0.3.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S11" "development-0.x" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.3
-  assert_calc "S12" "release-0.3" "false" "0.3.0-rc.0" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  assert_calc "S12" "release-0.3" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-rc.0" "true" "false" "false" "0.3" "tag"
   git tag 0.3.0-rc.0
 
   git checkout -q development-0.x
   commit_msg "fix: 5"
   sha_fix5="${LAST_COMMIT_SHA}"
-  assert_calc "S13" "development-0.x" "false" "0.4.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S13" "development-0.x" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.4.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-0.3
   cherry_pick_commit "${sha_fix5}"
-  assert_calc "S14" "release-0.3" "false" "0.3.0-rc.1" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  assert_calc "S14" "release-0.3" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-rc.1" "true" "false" "false" "0.3" "tag"
   git tag 0.3.0-rc.1
 
-  assert_calc "S15" "release-0.3" "true" "0.3.0" "false" "true" "false" "0.3" "merge-base" "0\.[0-9]+"
+  assert_calc "S15" "release-0.3" "0\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0" "false" "true" "false" "0.3" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.3.0
 
   git checkout -q development-0.x
   commit_msg "fix: 6"
   sha_fix6="${LAST_COMMIT_SHA}"
-  assert_calc "S19" "development-0.x" "false" "0.4.0-dev.2" "false" "false" "false" "" "tag" "0\.[0-9]+"
+  assert_calc "S19" "development-0.x" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.4.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q release-0.3
   cherry_pick_commit "${sha_fix6}"
-  assert_calc "S20" "release-0.3" "false" "0.3.1" "false" "true" "false" "0.3" "tag" "0\.[0-9]+"
+  assert_calc "S20" "release-0.3" "0\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.1" "false" "true" "false" "0.3" "tag"
   git tag 0.3.1
 
   git checkout -q development
   commit_msg "feat: 7"
   commit_msg "feat: 8"
-  assert_calc "S21" "development" "false" "1.1.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S21" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.1
-  assert_calc "S22" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  assert_calc "S22" "release-1.1" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
   git tag 1.1.0-rc.0
 
-  assert_calc "S23" "release-1.1" "true" "1.1.0" "false" "true" "true" "1.1" "merge-base"
+  assert_calc "S23" "release-1.1" "1\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0" "false" "true" "true" "1.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.1.0
 }

--- a/test/semantic_versioning.bats
+++ b/test/semantic_versioning.bats
@@ -19,7 +19,7 @@ setup() {
 # Helper functions
 
 commit_msg() {
-  local msg="$1"
+  local msg="${1}"
   COMMIT_COUNTER=$((COMMIT_COUNTER + 1))
   mkdir -p commits
   printf "%s\n" "${msg}" >"commits/${COMMIT_COUNTER}.txt"
@@ -29,12 +29,12 @@ commit_msg() {
 }
 
 cherry_pick_commit() {
-  local sha="$1"
+  local sha="${1}"
   git cherry-pick -x --no-edit "${sha}" >/dev/null
 }
 
 init_dummy_repo() {
-  local repo_dir="$1"
+  local repo_dir="${1}"
   mkdir -p "${repo_dir}"
   cd "${repo_dir}"
   git init -q --initial-branch=development
@@ -46,12 +46,13 @@ init_dummy_repo() {
 }
 
 read_output_key() {
-  local key="$1"
+  local key="${1}"
   grep "^${key}=" "${BATS_TEST_TMPDIR}/calc_output.txt" | tail -1 | cut -d= -f2-
 }
 
 run_calc() {
-  local promote="$1"
+  local promote="${1}"
+  local filter_version="${2}"
 
   local GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/calc_output.txt"
   local GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/calc_summary.md"
@@ -60,6 +61,7 @@ run_calc() {
   : >"${GITHUB_STEP_SUMMARY}"
 
   INPUT_PROMOTE="${promote}" \
+  INPUT_FILTER_VERSION="${filter_version}" \
   GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
   GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY}" \
   run bash "${ACTION_RUN_SCRIPT}"
@@ -79,18 +81,19 @@ run_calc() {
 }
 
 assert_calc() {
-  local scenario="$1"
-  local branch="$2"
-  local promote="$3"
-  local expected_next="$4"
-  local expected_is_rc="$5"
-  local expected_is_release="$6"
-  local expected_is_latest="$7"
-  local expected_release_line="$8"
-  local expected_changelog_mode="$9"
+  local scenario="${1}"
+  local branch="${2}"
+  local promote="${3}"
+  local expected_next="${4}"
+  local expected_is_rc="${5}"
+  local expected_is_release="${6}"
+  local expected_is_latest="${7}"
+  local expected_release_line="${8}"
+  local expected_changelog_mode="${9}"
+  local filter_version="${10}"
 
   git checkout -q "${branch}"
-  run_calc "${promote}"
+  run_calc "${promote}" "${filter_version}"
 
   # Bats assertions
   [ "${expected_next}" = "${CALC_NEXT_VERSION}" ] || { echo "FAIL ${scenario}: Expected next-version '${expected_next}', got '${CALC_NEXT_VERSION}'" >&3; return 1; }
@@ -225,4 +228,253 @@ assert_calc() {
   git checkout -q development
   commit_msg "fix: edge-after-rc-cut"
   assert_calc "E5" "development" "false" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+}
+
+@test "Two development branches" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/two-dev-branches"
+
+  commit_msg "chore: initial commit"
+  assert_calc "S0" "development" "false" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 1"
+  assert_calc "S1" "development" "false" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-0.1
+  assert_calc "S2" "release-0.1" "false" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0-rc.0
+
+  git checkout -q development
+  commit_msg "fix: 1"
+  sha_fix1="${LAST_COMMIT_SHA}"
+  assert_calc "S3" "development" "false" "0.2.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q release-0.1
+  cherry_pick_commit "${sha_fix1}"
+  assert_calc "S4" "release-0.1" "false" "0.1.0-rc.1" "true" "false" "false" "0.1" "tag"
+
+  assert_calc "S5" "release-0.1" "true" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0
+
+  git checkout -q development
+  commit_msg "feat: 2"
+  assert_calc "S6" "development" "false" "0.2.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-0.2
+  assert_calc "S7" "release-0.2" "false" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag"
+
+  assert_calc "S8" "release-0.2" "true" "0.2.0" "false" "true" "true" "0.2" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 0.2.0
+
+  git checkout -q development
+  commit_msg "fix: 2"
+  sha_fix2="${LAST_COMMIT_SHA}"
+  assert_calc "S9" "development" "false" "0.3.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q release-0.2
+  cherry_pick_commit "${sha_fix2}"
+  assert_calc "S10" "release-0.2" "true" "0.2.1" "false" "true" "true" "0.2" "tag"
+  git tag 0.2.1
+
+  git checkout -q development
+  commit_msg "feat: 3"
+  assert_calc "S11" "development" "false" "0.3.0-dev.2" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q -b development-1.0
+  commit_msg "feat: 4"
+  assert_calc "S12" "development-1.0" "false" "1.0.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q development
+  commit_msg "feat: 5"
+  commit_msg "feat: 6"
+  commit_msg "feat: 7"
+  assert_calc "S13" "development" "false" "0.3.0-dev.5" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q development-1.0
+  commit_msg "feat: 8"
+  assert_calc "S14" "development-1.0" "false" "1.0.0-dev.4" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.0
+  assert_calc "S15" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  git tag 1.0.0-rc.0
+
+  assert_calc "S16" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+
+  git checkout -q development
+  git checkout -q -b release-0.3
+  assert_calc "S17" "release-0.3" "false" "0.3.0-rc.0" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  git tag 0.3.0-rc.0
+
+  git checkout -q development
+  commit_msg "fix: 7"
+  sha_fix7="${LAST_COMMIT_SHA}"
+  assert_calc "S18" "development" "false" "0.4.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q release-0.3
+  cherry_pick_commit "${sha_fix7}"
+  assert_calc "S19" "release-0.3" "false" "0.3.0-rc.1" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  git tag 0.3.0-rc.1
+
+  assert_calc "S20" "release-0.3" "true" "0.3.0" "false" "true" "false" "0.3" "merge-base" "0\.[0-9]+"
+  commit_msg "[skip ci] Update version"
+  git tag 0.3.0
+
+  git checkout -q development-1.0
+  commit_msg "fix: 8"
+  sha_fix8="${LAST_COMMIT_SHA}"
+  commit_msg "feat: 9"
+  assert_calc "S21" "development-1.0" "false" "1.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.1
+  assert_calc "S22" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  git tag 1.1.0-rc.0
+
+  assert_calc "S23" "release-1.1" "true" "1.1.0" "false" "true" "true" "1.1" "merge-base"
+  git tag 1.1.0
+
+  git checkout -q development-1.0
+  commit_msg "fix: 9"
+  sha_fix9="${LAST_COMMIT_SHA}"
+  assert_calc "S24" "development-1.0" "false" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q release-1.0
+  cherry_pick_commit "${sha_fix9}"
+  assert_calc "S25" "release-1.0" "false" "1.0.1" "false" "true" "false" "1.0" "tag"
+  git tag 1.0.1
+
+  git checkout -q release-1.1
+  cherry_pick_commit "${sha_fix9}"
+  assert_calc "S26" "release-1.1" "false" "1.1.1" "false" "true" "true" "1.1" "tag"
+  git tag 1.1.1
+
+  git checkout -q development-1.0
+  commit_msg "feat: 10"
+  commit_msg "feat: 11"
+  assert_calc "S27" "development-1.0" "false" "1.2.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q development
+  commit_msg "feat: 12"
+  assert_calc "S28" "development" "false" "0.4.0-dev.2" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q -b release-0.4
+  assert_calc "S29" "release-0.4" "false" "0.4.0-rc.0" "true" "false" "false" "0.4" "tag" "0\.[0-9]+"
+  git tag 0.4.0-rc.0
+
+  assert_calc "S30" "release-0.4" "true" "0.4.0" "false" "true" "false" "0.4" "merge-base" "0\.[0-9]+"
+  commit_msg "[skip ci] Update version"
+  git tag 0.4.0
+
+  git checkout -q development-1.0
+  commit_msg "feat: 13"
+  commit_msg "fix: 11"
+  sha_fix11="${LAST_COMMIT_SHA}"
+  assert_calc "S31" "development-1.0" "false" "1.2.0-dev.5" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.2
+  assert_calc "S32" "release-1.2" "false" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
+  git tag 1.2.0-rc.0
+
+  git checkout -q release-1.2
+  assert_calc "S33" "release-1.2" "true" "1.2.0" "false" "true" "true" "1.2" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.2.0
+}
+
+@test "Swap development branches" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/swap-dev-branches"
+
+  commit_msg "chore: initial commit"
+  assert_calc "S0" "development" "false" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 1"
+  assert_calc "S1" "development" "false" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-0.1
+  assert_calc "S2" "release-0.1" "false" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0-rc.0
+
+  assert_calc "S3" "release-0.1" "true" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0
+
+  git checkout -q development
+  commit_msg "ci: filter 0.x versions"
+  assert_calc "S4" "development" "false" "0.2.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q -b development-1.x
+  commit_msg "feat: 3"
+  assert_calc "S5" "development-1.x" "false" "1.0.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.0
+  assert_calc "S6" "release-1.0" "false" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  git tag 1.0.0-rc.0
+
+  assert_calc "S7" "release-1.0" "true" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+
+  git checkout -q development
+  git checkout -q -b release-0.2
+  assert_calc "S8" "release-0.2" "false" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag" "0\.[0-9]+"
+  git tag 0.2.0-rc.0
+
+  assert_calc "S9" "release-0.2" "true" "0.2.0" "false" "true" "false" "0.2" "merge-base" "0\.[0-9]+"
+  commit_msg "[skip ci] Update version"
+  git tag 0.2.0
+
+  git branch -q -m development development-0.x
+  git branch -q -m development-1.x development
+  git checkout -q development
+  commit_msg "feat: 4"
+  assert_calc "S10" "development" "false" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q development-0.x
+  commit_msg "feat: 5"
+  assert_calc "S11" "development-0.x" "false" "0.3.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q -b release-0.3
+  assert_calc "S12" "release-0.3" "false" "0.3.0-rc.0" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  git tag 0.3.0-rc.0
+
+  git checkout -q development-0.x
+  commit_msg "fix: 5"
+  sha_fix5="${LAST_COMMIT_SHA}"
+  assert_calc "S13" "development-0.x" "false" "0.4.0-dev.1" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q release-0.3
+  cherry_pick_commit "${sha_fix5}"
+  assert_calc "S14" "release-0.3" "false" "0.3.0-rc.1" "true" "false" "false" "0.3" "tag" "0\.[0-9]+"
+  git tag 0.3.0-rc.1
+
+  assert_calc "S15" "release-0.3" "true" "0.3.0" "false" "true" "false" "0.3" "merge-base" "0\.[0-9]+"
+  commit_msg "[skip ci] Update version"
+  git tag 0.3.0
+
+  git checkout -q development-0.x
+  commit_msg "fix: 6"
+  sha_fix6="${LAST_COMMIT_SHA}"
+  assert_calc "S19" "development-0.x" "false" "0.4.0-dev.2" "false" "false" "false" "" "tag" "0\.[0-9]+"
+
+  git checkout -q release-0.3
+  cherry_pick_commit "${sha_fix6}"
+  assert_calc "S20" "release-0.3" "false" "0.3.1" "false" "true" "false" "0.3" "tag" "0\.[0-9]+"
+  git tag 0.3.1
+
+  git checkout -q development
+  commit_msg "feat: 7"
+  commit_msg "feat: 8"
+  assert_calc "S21" "development" "false" "1.1.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.1
+  assert_calc "S22" "release-1.1" "false" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
+  git tag 1.1.0-rc.0
+
+  assert_calc "S23" "release-1.1" "true" "1.1.0" "false" "true" "true" "1.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.1.0
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Introduce `filter-version` input for legacy development branches.

Current `development` branch has `0.x.x` releases and will be considered as legacy in future (ex. renamed to `development-0.x`). Experimental `development-1.0` branch has brand new code and will be released as `1.x.x` in future. We need to continue release `0.x.x` versions from `development-0.x` branch after `1.0.0` will be released.

Example for application repo:

```yaml
jobs:
  release:
    uses: epam/ai-dial-ci/.github/workflows/node_release.yml@main
    with:
      [skipped]
      filter-version: '0\.[0-9]+' # Add version filter for "legacy" branch
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] run `bats test`
- [X] test on repository fork

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
