### PR TITLE
chore: update Deploy development workflow sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,6 @@ jobs:
   gitlab-dev-deploy:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
     uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@main
     with:
@@ -990,7 +989,6 @@ jobs:
   trigger:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ jobs:
 
 #### Trigger deployment of development environment in GitLab
 
-A common case is to trigger development environment(s) update from GitHub to GitLab, e.g. each time a `development` branch produces a new artifact. Also, it could be not single, but several environments, representing different configuration presets of a single app. To use the example below:
+A common case is to trigger development environment(s) update from GitHub to GitLab, e.g. after a successful release workflow produces a new artifact. Also, it could be not single, but several environments, representing different configuration presets of a single app. To use the example below:
 
 1. add a new [repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) with name `DEPLOY_HOST` and value of the gitlab host, e.g. `gitlab.example.com`
 1. create a new [environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#creating-an-environment), e.g. `development`
@@ -952,8 +952,7 @@ name: Deploy development
 
 on:
   workflow_dispatch: # manual run
-  registry_package: # on new package version (main path)
-  workflow_run: # HACK: redundant trigger to mitigate GitHub's huge delays in registry_package event processing
+  workflow_run:
     workflows: ["Release Workflow"]
     types:
       - completed
@@ -982,8 +981,7 @@ name: Deploy development
 
 on:
   workflow_dispatch: # manual run
-  registry_package: # on new package version (main path)
-  workflow_run: # HACK: redundant trigger to mitigate GitHub's huge delays in registry_package event processing
+  workflow_run:
     workflows: ["Release Workflow"]
     types:
       - completed


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Context / Problem: The `Deploy development` workflow is currently configured with multiple triggers. The combination of `registry_package` and `workflow_run` causes redundant deployments. After a successful `Release Workflow`, the `Deploy development` workflow triggers twice:
- Immediately after the `Release Workflow` finishes (via `workflow_run`).
- Approximately 30 minutes later, when the new package versions are finally detected (via `registry_package`).

This PR resolves the issue by removing the redundant trigger (`registry_package`), ensuring the deployment only runs once.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.