### PR TITLE
fix: fix strict version filter

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.6.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.6.1
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -110,7 +110,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -153,7 +153,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -161,7 +161,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
         env:
           IMAGE_NAME: ${{ github.repository }}
 
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -151,7 +151,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -195,7 +195,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -203,7 +203,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -211,7 +211,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -234,7 +234,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.6.1
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -150,7 +150,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -150,7 +150,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -194,7 +194,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -202,7 +202,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -213,7 +213,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -286,7 +286,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.6.1
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -132,7 +132,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -175,7 +175,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.6.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.6.1
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -208,7 +208,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -132,7 +132,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.6.1
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -149,7 +149,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.6.1
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -157,7 +157,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -172,7 +172,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.6.1
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.1
         with:
           python-version: ${{ inputs.python-version }}
           poetry-version: ${{ inputs.poetry-version }}
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.6.1
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ inputs.poetry-version }}

--- a/actions/publish_tag_release/action.yml
+++ b/actions/publish_tag_release/action.yml
@@ -34,7 +34,7 @@ runs:
 
         ${{ inputs.extra-commit-command }}
 
-        git tag -a "${{ inputs.tag-version }}" -m "$(cat ${{ inputs.changelog-file }})"
+        git tag -a "${{ inputs.tag-version }}" -F "${{ inputs.changelog-file }}"
 
         git push
         git push --tags

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -114,17 +114,21 @@ runs:
 
           DEV_SOURCE=""  # "stable", "rc", or ""
           if [[ -n "${LATEST_STABLE_LINE}" && -n "${LATEST_RC_LINE}" ]]; then
-            if semver "${LATEST_STABLE_LINE}.0" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1 && semver "${LATEST_RC_LINE}.0" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1; then
+            if semver --include-prerelease "${LATEST_STABLE_LINE}.0" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1 && semver --include-prerelease "${LATEST_RC_LINE}.0" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1; then
               DEV_SOURCE="branch"
-            elif semver "${LATEST_STABLE_LINE}.0" --range ">=${LATEST_RC_LINE}.0" >/dev/null 2>&1; then
+            elif semver --include-prerelease "${LATEST_STABLE_LINE}.0" --range ">=${LATEST_RC_LINE}.0" >/dev/null 2>&1; then
               DEV_SOURCE="stable"
             else
               DEV_SOURCE="rc"
             fi
-          elif [[ -n "${BRANCH_LINE}" && -z "${LATEST_STABLE_LINE}" && -n "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] && semver "${LATEST_STABLE_TAG_WITHOUT_FILTER}" --range "<${INITIAL_BRANCH_VERSION}"; then
-            LATEST_STABLE_TAG="${LATEST_STABLE_TAG_WITHOUT_FILTER}"
-            DEV_SOURCE="branch"
-          elif [[ -n "${BRANCH_LINE}" && -z "${LATEST_RC_LINE}" && -n "${LATEST_RC_TAG_WITHOUT_FILTER}" ]] && semver "${LATEST_RC_TAG_WITHOUT_FILTER}" --range "<${INITIAL_BRANCH_VERSION}"; then
+          elif [[ -n "${BRANCH_LINE}" && -z "${LATEST_STABLE_LINE}" && -n "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] && semver --include-prerelease "${LATEST_STABLE_TAG_WITHOUT_FILTER}" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1; then
+            if [[ -n "${LATEST_RC_TAG}" && -n "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] && semver --include-prerelease "${LATEST_RC_TAG}" --range ">${LATEST_STABLE_TAG_WITHOUT_FILTER}"; then
+              DEV_SOURCE=rc
+            else
+              LATEST_STABLE_TAG="${LATEST_STABLE_TAG_WITHOUT_FILTER}"
+              DEV_SOURCE="branch"
+            fi
+          elif [[ -n "${BRANCH_LINE}" && -z "${LATEST_RC_LINE}" && -n "${LATEST_RC_TAG_WITHOUT_FILTER}" ]] && semver --include-prerelease "${LATEST_RC_TAG_WITHOUT_FILTER}" --range "<${INITIAL_BRANCH_VERSION}" >/dev/null 2>&1; then
             LATEST_RC_TAG="${LATEST_RC_TAG_WITHOUT_FILTER}"
             DEV_SOURCE=branch
           elif [[ -n "${LATEST_STABLE_LINE}" ]]; then
@@ -146,7 +150,7 @@ runs:
               ;;
             branch)
               if [[ -n "${LATEST_STABLE_TAG}" && -n "${LATEST_RC_TAG}" ]]; then
-                if semver "${LATEST_STABLE_TAG}" --range ">${LATEST_RC_TAG}" >/dev/null 2>&1; then
+                if semver --include-prerelease "${LATEST_STABLE_TAG}" --range ">${LATEST_RC_TAG}" >/dev/null 2>&1; then
                   DEV_N=$(git rev-list --count "${LATEST_STABLE_TAG}..HEAD")
                 else
                   DEV_N=$(git rev-list --count "${LATEST_RC_TAG}..HEAD")
@@ -182,7 +186,7 @@ runs:
             CURRENT_VERSION="${STABLE_TAG}"
             NEXT_VERSION=$(semver "${CURRENT_VERSION}" --increment patch)
             IS_RELEASE="true"
-            if [[ -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] || semver "${NEXT_VERSION}" --range ">${LATEST_STABLE_TAG_WITHOUT_FILTER}" >/dev/null 2>&1; then
+            if [[ -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] || semver --include-prerelease "${NEXT_VERSION}" --range ">${LATEST_STABLE_TAG_WITHOUT_FILTER}" >/dev/null 2>&1; then
               IS_LATEST="true"
             fi
 
@@ -192,7 +196,7 @@ runs:
             NEXT_VERSION="${RELEASE_LINE}.0"
             CHANGELOG_MODE="merge-base"
             IS_RELEASE="true"
-            if [[ -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] || semver "${NEXT_VERSION}" --range ">${LATEST_STABLE_TAG_WITHOUT_FILTER}" >/dev/null 2>&1; then
+            if [[ -z "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] || semver --include-prerelease "${NEXT_VERSION}" --range ">${LATEST_STABLE_TAG_WITHOUT_FILTER}" >/dev/null 2>&1; then
               IS_LATEST="true"
             fi
 
@@ -204,11 +208,13 @@ runs:
             if [[ -n "${LATEST_RC}" ]]; then
               CURRENT_VERSION="${LATEST_RC}"
               NEXT_VERSION=$(semver "${LATEST_RC}" --increment prerelease --preid rc)
-
             else
               CURRENT_VERSION=""
               NEXT_VERSION="${RELEASE_LINE}.0-rc.0"
             fi
+          fi
+          if [[ -z "${LATEST_STABLE_TAG}" && -n "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] && semver --include-prerelease "${LATEST_STABLE_TAG_WITHOUT_FILTER}" --range "<${RELEASE_LINE}.0" >/dev/null 2>&1; then
+            LATEST_STABLE_TAG="${LATEST_STABLE_TAG_WITHOUT_FILTER}"
           fi
 
         else

--- a/actions/semantic_versioning/action.yml
+++ b/actions/semantic_versioning/action.yml
@@ -76,6 +76,7 @@ runs:
         IS_LATEST="false"
         CHANGELOG_MODE="tag"
         RELEASE_LINE=""
+        BRANCH_LINE=""
         DEV_SOURCE=""
 
         git fetch --tags
@@ -86,6 +87,7 @@ runs:
         LATEST_STABLE_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.[0-9]+$" | sort -V | tail -1 || true)
         LATEST_STABLE_TAG_WITHOUT_FILTER=$(git tag | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1 || true)
         LATEST_RC_TAG=$(git tag | grep -E "^${INPUT_FILTER_VERSION}\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
+        LATEST_RC_TAG_WITHOUT_FILTER=$(git tag | grep -E "^[0-9]+\.[0-9]+\.0-rc\.[0-9]+$" | sort -V | tail -1 || true)
 
         if [[ "${CURRENT_BRANCH}" =~ ${PRIMARY_BRANCH_PATTERN} ]]; then
           # Determine which is greater: latest stable tag or latest RC tag
@@ -119,6 +121,12 @@ runs:
             else
               DEV_SOURCE="rc"
             fi
+          elif [[ -n "${BRANCH_LINE}" && -z "${LATEST_STABLE_LINE}" && -n "${LATEST_STABLE_TAG_WITHOUT_FILTER}" ]] && semver "${LATEST_STABLE_TAG_WITHOUT_FILTER}" --range "<${INITIAL_BRANCH_VERSION}"; then
+            LATEST_STABLE_TAG="${LATEST_STABLE_TAG_WITHOUT_FILTER}"
+            DEV_SOURCE="branch"
+          elif [[ -n "${BRANCH_LINE}" && -z "${LATEST_RC_LINE}" && -n "${LATEST_RC_TAG_WITHOUT_FILTER}" ]] && semver "${LATEST_RC_TAG_WITHOUT_FILTER}" --range "<${INITIAL_BRANCH_VERSION}"; then
+            LATEST_RC_TAG="${LATEST_RC_TAG_WITHOUT_FILTER}"
+            DEV_SOURCE=branch
           elif [[ -n "${LATEST_STABLE_LINE}" ]]; then
             DEV_SOURCE="stable"
           elif [[ -n "${LATEST_RC_LINE}" ]]; then

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -23,12 +23,12 @@
   - [Multiple Development Branches](#multiple-development-branches)
 
 1. A `development` is the branch for all new work
-2. A `development-N.x` is the branch for the next major version (`N.x.x`) which is developed in parallel with code in `development` branch
-3. All code changes are merged from feature branches to `development` or `development-N.x` via pull requests
-4. When there's enough changes in `development` or `development-N.x` for a new release, maintainer cuts `release-X.Y` branch. Release enters stabilization phase, the branch produce numbered RC artifacts (`X.Y.0-rc.N`)
-5. Once the maintainer decides the release is stable, he manually (`workflow_dispatch`) triggers `Release Workflow` for `release-X.Y` branch with `promote` option set. Stable `X.Y.0` is published
-6. Since that moment, `release-X.Y` enters maintenance phase, and any subsequent pushes to that branch produce patches (`X.Y.1`, `X.Y.2`, ...)
-7. Fixes to maintenance branches must be backported from `development` or `development-N.x` branch via cherry-picks
+1. A `development-N.x` is the branch for the next major version (`N.x.x`) which is developed in parallel with code in `development` branch
+1. All code changes are merged from feature branches to `development` or `development-N.x` via pull requests
+1. When there's enough changes in `development` or `development-N.x` for a new release, maintainer cuts `release-X.Y` branch. Release enters stabilization phase, the branch produce numbered RC artifacts (`X.Y.0-rc.N`)
+1. Once the maintainer decides the release is stable, he manually (`workflow_dispatch`) triggers `Release Workflow` for `release-X.Y` branch with `promote` option set. Stable `X.Y.0` is published
+1. Since that moment, `release-X.Y` enters maintenance phase, and any subsequent pushes to that branch produce patches (`X.Y.1`, `X.Y.2`, ...)
+1. Fixes to maintenance branches must be backported from `development` or `development-N.x` branch via cherry-picks
 
 > **IMPORTANT!** For `development-N.x` branches initial version will be forced to `N.0.0`. Before creating `release-N.0` branch repository maintainer should set version filter (`filter-version`) on "legacy" branches (ex. `development`). The most recent development branch does not require version filter.
 

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -1236,7 +1236,7 @@ gh release view 1.0.2 --json body | jq -r '.body'
 
 ## Multiple Development Branches
 
-> **IMPORTANT!** Multiple development branches workflow should be treated as available workaround and not recommended for every repository.
+> **IMPORTANT!** Multiple development branches workflow should be treated as workaround and not recommended for every repository.
 
 1. A `development` is the branch for all new work
 1. A `development-X.x` is the branch for the next major version (`X.0.0`) which is developed in parallel with code in `development` branch

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -23,14 +23,11 @@
   - [Multiple Development Branches](#multiple-development-branches)
 
 1. A `development` is the branch for all new work
-1. A `development-N.x` is the branch for the next major version (`N.x.x`) which is developed in parallel with code in `development` branch
-1. All code changes are merged from feature branches to `development` or `development-N.x` via pull requests
-1. When there's enough changes in `development` or `development-N.x` for a new release, maintainer cuts `release-X.Y` branch. Release enters stabilization phase, the branch produce numbered RC artifacts (`X.Y.0-rc.N`)
+1. All code changes are merged from feature branches to `development` via pull requests
+1. When there's enough changes in `development` for a new release, maintainer cuts `release-X.Y` branch. Release enters stabilization phase, the branch produce numbered RC artifacts (`X.Y.0-rc.N`)
 1. Once the maintainer decides the release is stable, he manually (`workflow_dispatch`) triggers `Release Workflow` for `release-X.Y` branch with `promote` option set. Stable `X.Y.0` is published
 1. Since that moment, `release-X.Y` enters maintenance phase, and any subsequent pushes to that branch produce patches (`X.Y.1`, `X.Y.2`, ...)
-1. Fixes to maintenance branches must be backported from `development` or `development-N.x` branch via cherry-picks
-
-> **IMPORTANT!** For `development-N.x` branches initial version will be forced to `N.0.0`. Before creating `release-N.0` branch repository maintainer should set version filter (`filter-version`) on "legacy" branches (ex. `development`). The most recent development branch does not require version filter.
+1. Fixes to maintenance branches must be backported from `development` branch via cherry-picks
 
 ## Version Scheme
 
@@ -1239,13 +1236,62 @@ gh release view 1.0.2 --json body | jq -r '.body'
 
 ## Multiple Development Branches
 
->**IMPORTANT!** The main difference is requirement to limit versions for "legacy" branches **before** the first release from `development-N.x` branch.
+> **IMPORTANT!** Multiple development branches workflow should be treated as available workaround and not recommended for every repository.
 
-1. Create `development` branch and start coding
-1. Release `1.X.Y` versions by creating `release-1.X` branches
-1. Create `development-2.x` branch from `development` branch
-1. Limit `development` branch to `1.X.Y` versions by setting `version-filter: '1\.[0-9]+'` in `development` branch (use regex to match major and minor version only)
-1. Release `2.X.Y` versions by creating `release-2.X` release branch
-1. At some point rename `development` branch to `development-1.x` and `development-2.x` branch to `development`, correct branch filter in workflows accordingly.
+1. A `development` is the branch for all new work
+1. A `development-X.x` is the branch for the next major version (`X.0.0`) which is developed in parallel with code in `development` branch
+1. All code changes are merged from feature branches to `development` or `development-X.x` via pull requests
+1. When there's enough changes in `development` or `development-X.x` for a new release, maintainer cuts `release-X.Y` branch. Release enters stabilization phase, the branch produce numbered RC artifacts (`X.Y.0-rc.N`)
+1. Once the maintainer decides the release is stable, he manually (`workflow_dispatch`) triggers `Release Workflow` for `release-X.Y` branch with `promote` option set. Stable `X.Y.0` is published
+1. Since that moment, `release-X.Y` enters maintenance phase, and any subsequent pushes to that branch produce patches (`X.Y.1`, `X.Y.2`, ...)
+1. Fixes to maintenance branches must be backported from `development` or `development-X.x` branch via cherry-picks
 
-RC promotion and fixes should be done as for regular `development` branch.
+> **IMPORTANT!** For `development-X.x` branches initial version will be forced to `X.0.0`. Do not create branches like `development-1.5`, `development-2.4`, etc. Before creating `release-X.0` branch repository maintainer should set version filter (`filter-version`) on "legacy" branches (ex. `development`). The most recent development branch does not require version filter.
+
+```mermaid
+---
+config:
+  gitGraph:
+    mainBranchName: "development"
+---
+gitGraph
+    commit id: "chore: initial commit"
+    commit id: "feat: 1"
+    branch release-1.0
+    commit id: "\[skip ci\] Update version (1.0.0-rc.0)" tag: "1.0.0-rc.0"
+    checkout development
+    commit id: "fix: 1"
+    checkout release-1.0
+    cherry-pick id: "fix: 1"
+    commit id: "\[skip ci\] Update version (1.0.0-rc.1)" tag: "1.0.0-rc.1"
+    commit id: "\[skip ci\] Update version (1.0.0)" type: HIGHLIGHT tag: "1.0.0"
+    checkout development
+    commit id: "feat: 2"
+    commit id: "fix: 2"
+    checkout release-1.0
+    cherry-pick id: "fix: 2"
+    commit id: "\[skip ci\] Update version (1.0.1)" tag: "1.0.1"
+    checkout development
+    branch release-1.1
+    commit id: "\[skip ci\] Update version (1.1.0-rc.0)" tag: "1.1.0-rc.0"
+    commit id: "\[skip ci\] Update version (1.1.0)" type: HIGHLIGHT tag: "1.1.0"
+    branch development-2.x
+    commit id: "feat: 3"
+    commit id: "feat: 4"
+    checkout development
+    commit id: "set filter version '1\.[0-9]+'"
+    checkout development-2.x
+    branch release-2.0
+    commit id: "\[skip ci\] Update version (2.0.0-rc.0)" tag: "2.0.0-rc.0"
+    commit id: "\[skip ci\] Update version (2.0.0)" type: HIGHLIGHT tag: "2.0.0"
+    checkout development
+    commit id: "feat: 6"
+    branch release-1.2
+    commit id: "\[skip ci\] Update version (1.2.0-rc.0)" tag: "1.2.0-rc.0"
+    checkout development
+    commit id: "fix: 6"
+    checkout release-1.2
+    cherry-pick id: "fix: 6"
+    commit id: "\[skip ci\] Update version (1.2.0-rc.1)" tag: "1.2.0-rc.1"
+    commit id: "\[skip ci\] Update version (1.2.0)" type: HIGHLIGHT tag: "1.2.0"
+```

--- a/docs/BRANCHING_STRATEGY.md
+++ b/docs/BRANCHING_STRATEGY.md
@@ -1,11 +1,36 @@
 # Branching Strategy
 
+- [Branching Strategy](#branching-strategy)
+  - [Version Scheme](#version-scheme)
+  - [Example Repository Lifecycle](#example-repository-lifecycle)
+    - [Scenario 0 - First push to `development` (repo is empty)](#scenario-0---first-push-to-development-repo-is-empty)
+    - [Scenario 1 - Second push to `development`](#scenario-1---second-push-to-development)
+    - [Scenario 2 - `release-1.0` creation (no tags or other release branches exist)](#scenario-2---release-10-creation-no-tags-or-other-release-branches-exist)
+    - [Scenario 3 - push to `development` when `release-1.0` exists with RC tags (no stable yet)](#scenario-3---push-to-development-when-release-10-exists-with-rc-tags-no-stable-yet)
+    - [Scenario 4 - pick fix onto `release-1.0` while RC tags exist, but no stable yet](#scenario-4---pick-fix-onto-release-10-while-rc-tags-exist-but-no-stable-yet)
+    - [Scenario 5 - `workflow_dispatch promote=true` on `release-1.0`](#scenario-5---workflow_dispatch-promotetrue-on-release-10)
+    - [Scenario 6 - Sequential push of 2 commits to `development` after stable `1.0.0` exists](#scenario-6---sequential-push-of-2-commits-to-development-after-stable-100-exists)
+    - [Scenario 7 - Backport fix to `release-1.0` after stable `1.0.0` exists (first patch)](#scenario-7---backport-fix-to-release-10-after-stable-100-exists-first-patch)
+    - [Scenario 8 - Cutting `release-1.1`](#scenario-8---cutting-release-11)
+    - [Scenario 9 - Promote `release-1.1` to stable](#scenario-9---promote-release-11-to-stable)
+    - [Scenario 10 - Push to `development` after stable `1.1.0` exists](#scenario-10---push-to-development-after-stable-110-exists)
+    - [Scenario 11 - Cutting `release-1.2`](#scenario-11---cutting-release-12)
+    - [Scenario 12 - Promote `release-1.2` to stable](#scenario-12---promote-release-12-to-stable)
+    - [Scenario 13 - Push more commits to `development` as regular repo lifecycle continues](#scenario-13---push-more-commits-to-development-as-regular-repo-lifecycle-continues)
+    - [Scenario 14 - Backport fix to `release-1.1` (patch on middle release line)](#scenario-14---backport-fix-to-release-11-patch-on-middle-release-line)
+    - [Scenario 15 - Backport fix to `release-1.2` (patch on highest release line)](#scenario-15---backport-fix-to-release-12-patch-on-highest-release-line)
+    - [Scenario 16 - Backport fix to `release-1.0` (patch on oldest release line)](#scenario-16---backport-fix-to-release-10-patch-on-oldest-release-line)
+  - [Multiple Development Branches](#multiple-development-branches)
+
 1. A `development` is the branch for all new work
-1. All code changes are merged from feature branches to `development` via pull requests
-1. When there's enough changes in `development` for a new release, maintainer cuts `release-X.Y` branch. Release enters stabilization phase, the branch produce numbered RC artifacts (`X.Y.0-rc.N`)
-1. Once the maintainer decides the release is stable, he manually (`workflow_dispatch`) triggers `Release Workflow` for `release-X.Y` branch with `promote` option set. Stable `X.Y.0` is published
-1. Since that moment, `release-X.Y` enters maintenance phase, and any subsequent pushes to that branch produce patches (`X.Y.1`, `X.Y.2`, ...)
-1. Fixes to maintenance branches must be backported from `development` branch via cherry-picks
+2. A `development-N.x` is the branch for the next major version (`N.x.x`) which is developed in parallel with code in `development` branch
+3. All code changes are merged from feature branches to `development` or `development-N.x` via pull requests
+4. When there's enough changes in `development` or `development-N.x` for a new release, maintainer cuts `release-X.Y` branch. Release enters stabilization phase, the branch produce numbered RC artifacts (`X.Y.0-rc.N`)
+5. Once the maintainer decides the release is stable, he manually (`workflow_dispatch`) triggers `Release Workflow` for `release-X.Y` branch with `promote` option set. Stable `X.Y.0` is published
+6. Since that moment, `release-X.Y` enters maintenance phase, and any subsequent pushes to that branch produce patches (`X.Y.1`, `X.Y.2`, ...)
+7. Fixes to maintenance branches must be backported from `development` or `development-N.x` branch via cherry-picks
+
+> **IMPORTANT!** For `development-N.x` branches initial version will be forced to `N.0.0`. Before creating `release-N.0` branch repository maintainer should set version filter (`filter-version`) on "legacy" branches (ex. `development`). The most recent development branch does not require version filter.
 
 ## Version Scheme
 
@@ -1211,3 +1236,16 @@ gh release view 1.0.2 --json isPrerelease
 gh release view 1.0.2 --json body | jq -r '.body'
 # --> fix: 5
 ```
+
+## Multiple Development Branches
+
+>**IMPORTANT!** The main difference is requirement to limit versions for "legacy" branches **before** the first release from `development-N.x` branch.
+
+1. Create `development` branch and start coding
+1. Release `1.X.Y` versions by creating `release-1.X` branches
+1. Create `development-2.x` branch from `development` branch
+1. Limit `development` branch to `1.X.Y` versions by setting `version-filter: '1\.[0-9]+'` in `development` branch (use regex to match major and minor version only)
+1. Release `2.X.Y` versions by creating `release-2.X` release branch
+1. At some point rename `development` branch to `development-1.x` and `development-2.x` branch to `development`, correct branch filter in workflows accordingly.
+
+RC promotion and fixes should be done as for regular `development` branch.

--- a/test/semantic_versioning.bats
+++ b/test/semantic_versioning.bats
@@ -684,7 +684,18 @@ assert_calc() {
   assert_calc "S7" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   git tag 1.0.0-rc.0
 
-  assert_calc "S8" "release-1.0" "[0-9]+\.[0-9]+" "true" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  git checkout -q development-1.x
+  commit_msg "fix: 4"
+  local sha_fix4="${LAST_COMMIT_SHA}"
+  assert_calc "S8" "development-1.x" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q release-1.0
+  cherry_pick_commit "${sha_fix4}"
+  assert_calc "S9" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.1
+
+  assert_calc "S10" "release-1.0" "[0-9]+\.[0-9]+" "true" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 }
@@ -722,7 +733,18 @@ assert_calc() {
   assert_calc "S7" "release-1.0" "1\.[0-9]+" "false" "^development-1\.x$" "^release-1\.[0-9]+$" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   git tag 1.0.0-rc.0
 
-  assert_calc "S8" "release-1.0" "1\.[0-9]+" "true" "^development-1\.x$" "^release-1\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  git checkout -q development-1.x
+  commit_msg "fix: 4"
+  local sha_fix4="${LAST_COMMIT_SHA}"
+  assert_calc "S8" "development-1.x" "1\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q release-1.0
+  cherry_pick_commit "${sha_fix4}"
+  assert_calc "S9" "release-1.0" "1\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.1
+
+  assert_calc "S10" "release-1.0" "1\.[0-9]+" "true" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 }

--- a/test/semantic_versioning.bats
+++ b/test/semantic_versioning.bats
@@ -650,3 +650,146 @@ assert_calc() {
   commit_msg "[skip ci] Update version"
   git tag 1.1.0
 }
+
+@test "Default version filter" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/default-version-filter"
+
+  commit_msg "chore: initial commit"
+  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 1"
+  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-0.1
+  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0-rc.0
+
+  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0
+
+  git checkout -q development
+  commit_msg "ci: filter 0.x versions"
+  assert_calc "S4" "development" "0\.[0-9]+" "false" "^development$" "^release-0\.[0-9]+$" "0.2.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q -b development-1.x
+  commit_msg "feat: 3"
+  assert_calc "S5" "development-1.x" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-dev.2" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 4"
+  assert_calc "S6" "development-1.x" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.0
+  assert_calc "S7" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  git tag 1.0.0-rc.0
+
+  assert_calc "S8" "release-1.0" "[0-9]+\.[0-9]+" "true" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+}
+
+@test "Strict version filter" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/strict-version-filter"
+
+  commit_msg "chore: initial commit"
+  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 1"
+  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-0.1
+  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0-rc.0
+
+  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0
+
+  git checkout -q development
+  commit_msg "ci: filter 0.x versions"
+  assert_calc "S4" "development" "0\.[0-9]+" "false" "^development$" "^release-0\.[0-9]+$" "0.2.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q -b development-1.x
+  commit_msg "feat: 3"
+  assert_calc "S5" "development-1.x" "1\.[0-9]+" "false" "^development-1\.x$" "^release-1\.[0-9]+$" "1.0.0-dev.2" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 4"
+  assert_calc "S6" "development-1.x" "1\.[0-9]+" "false" "^development-1\.x$" "^release-1\.[0-9]+$" "1.0.0-dev.3" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-1.0
+  assert_calc "S7" "release-1.0" "1\.[0-9]+" "false" "^development-1\.x$" "^release-1\.[0-9]+$" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  git tag 1.0.0-rc.0
+
+  assert_calc "S8" "release-1.0" "1\.[0-9]+" "true" "^development-1\.x$" "^release-1\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+}
+
+@test "Bump major version using long RC" {
+  init_dummy_repo "${BATS_TEST_TMPDIR}/bump-major-version-using-long-rc"
+
+  commit_msg "chore: initial commit"
+  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+
+  commit_msg "feat: 1"
+  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+
+  git checkout -q -b release-0.1
+  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0-rc.0
+
+  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 0.1.0
+
+  git checkout -q development
+  git checkout -q -b development-0.x
+  commit_msg "ci: legacy 0.x versions"
+  assert_calc "S4" "development-0.x" "0\.[0-9]+" "false" "^development-0\.x$" "^release-0\.[0-9]+" "0.2.0-dev.1" "false" "false" "false" "" "tag"
+
+  git checkout -q development
+  git checkout -q -b release-1.0
+  assert_calc "S5" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.0
+
+  git checkout -q development
+  commit_msg "feat: 2"
+  local sha_feat2="${LAST_COMMIT_SHA}"
+  commit_msg "feat: 3"
+  local sha_feat3="${LAST_COMMIT_SHA}"
+  commit_msg "feat: 4"
+  local sha_feat4="${LAST_COMMIT_SHA}"
+  commit_msg "feat: 5"
+  local sha_feat5="${LAST_COMMIT_SHA}"
+  assert_calc "S6" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.1.0-dev.4" "false" "false" "false" "" "tag"
+
+  git checkout -q release-1.0
+  cherry_pick_commit "${sha_feat2}"
+  cherry_pick_commit "${sha_feat3}"
+  cherry_pick_commit "${sha_feat4}"
+  cherry_pick_commit "${sha_feat5}"
+  assert_calc "S7" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0-rc.1
+
+  assert_calc "S8" "release-1.0" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 1.0.0
+
+  git checkout -q development-0.x
+  git checkout -q -b release-0.2
+  assert_calc "S9" "release-0.2" "0\.[0-9]+" "false" "^development-0\.x$" "^release-0\.[0-9]+" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag"
+  git tag 0.2.0-rc.0
+
+  assert_calc "S10" "release-0.2" "0\.[0-9]+" "true" "^development-0\.x$" "^release-0\.[0-9]+" "0.2.0" "false" "true" "false" "0.2" "merge-base"
+  commit_msg "[skip ci] Update version"
+  git tag 0.2.0
+
+  git checkout -q development
+  commit_msg "feat: 6"
+  assert_calc "S11" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.1.0-dev.5" "false" "false" "false" "" "tag"
+}

--- a/test/semantic_versioning.bats
+++ b/test/semantic_versioning.bats
@@ -403,48 +403,48 @@ assert_calc() {
   local RELEASE_PATTERN="^release-[0-9]+\.[0-9]+$"
 
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S0" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S1" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.1
-  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  assert_calc "S2" "release-0.1" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0-rc.0
 
   git checkout -q development
   commit_msg "fix: 1"
   sha_fix1="${LAST_COMMIT_SHA}"
-  assert_calc "S3" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S3" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-0.1
   cherry_pick_commit "${sha_fix1}"
-  assert_calc "S4" "release-0.1" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.1" "true" "false" "false" "0.1" "tag"
+  assert_calc "S4" "release-0.1" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.1" "true" "false" "false" "0.1" "tag"
 
-  assert_calc "S5" "release-0.1" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  assert_calc "S5" "release-0.1" "" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0" "false" "true" "true" "0.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0
 
   git checkout -q development
   commit_msg "feat: 2"
-  assert_calc "S6" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S6" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.2
-  assert_calc "S7" "release-0.2" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag"
+  assert_calc "S7" "release-0.2" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0-rc.0" "true" "false" "false" "0.2" "tag"
 
-  assert_calc "S8" "release-0.2" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0" "false" "true" "true" "0.2" "merge-base"
+  assert_calc "S8" "release-0.2" "" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.0" "false" "true" "true" "0.2" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.2.0
 
   git checkout -q development
   commit_msg "fix: 2"
   sha_fix2="${LAST_COMMIT_SHA}"
-  assert_calc "S9" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S9" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.3.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-0.2
   cherry_pick_commit "${sha_fix2}"
-  assert_calc "S10" "release-0.2" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.1" "false" "true" "true" "0.2" "tag"
+  assert_calc "S10" "release-0.2" "" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.2.1" "false" "true" "true" "0.2" "tag"
   git tag 0.2.1
 
   git checkout -q development
@@ -453,7 +453,7 @@ assert_calc() {
 
   git checkout -q -b development-1.0
   commit_msg "feat: 4"
-  assert_calc "S12" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S12" "development-1.0" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q development
   commit_msg "feat: 5"
@@ -463,7 +463,7 @@ assert_calc() {
 
   git checkout -q development-1.0
   commit_msg "feat: 8"
-  assert_calc "S14" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.4" "false" "false" "false" "" "tag"
+  assert_calc "S14" "development-1.0" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.4" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.0
   assert_calc "S15" "release-1.0" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
@@ -496,7 +496,7 @@ assert_calc() {
   commit_msg "fix: 8"
   sha_fix8="${LAST_COMMIT_SHA}"
   commit_msg "feat: 9"
-  assert_calc "S21" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S21" "development-1.0" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.1
   assert_calc "S22" "release-1.1" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
@@ -508,7 +508,7 @@ assert_calc() {
   git checkout -q development-1.0
   commit_msg "fix: 9"
   sha_fix9="${LAST_COMMIT_SHA}"
-  assert_calc "S24" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S24" "development-1.0" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-1.0
   cherry_pick_commit "${sha_fix9}"
@@ -523,7 +523,7 @@ assert_calc() {
   git checkout -q development-1.0
   commit_msg "feat: 10"
   commit_msg "feat: 11"
-  assert_calc "S27" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S27" "development-1.0" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q development
   commit_msg "feat: 12"
@@ -541,7 +541,7 @@ assert_calc() {
   commit_msg "feat: 13"
   commit_msg "fix: 11"
   sha_fix11="${LAST_COMMIT_SHA}"
-  assert_calc "S31" "development-1.0" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.5" "false" "false" "false" "" "tag"
+  assert_calc "S31" "development-1.0" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-dev.5" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.2
   assert_calc "S32" "release-1.2" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.2.0-rc.0" "true" "false" "false" "1.2" "tag"
@@ -560,17 +560,17 @@ assert_calc() {
   local RELEASE_PATTERN="^release-[0-9]+\.[0-9]+$"
 
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S0" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S1" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.1
-  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  assert_calc "S2" "release-0.1" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0-rc.0
 
-  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  assert_calc "S3" "release-0.1" "" "true" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "0.1.0" "false" "true" "true" "0.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0
 
@@ -580,7 +580,7 @@ assert_calc() {
 
   git checkout -q -b development-1.x
   commit_msg "feat: 3"
-  assert_calc "S5" "development-1.x" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S5" "development-1.x" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.0
   assert_calc "S6" "release-1.0" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
@@ -603,7 +603,7 @@ assert_calc() {
   git branch -q -m development-1.x development
   git checkout -q development
   commit_msg "feat: 4"
-  assert_calc "S10" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S10" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q development-0.x
   commit_msg "feat: 5"
@@ -640,7 +640,7 @@ assert_calc() {
   git checkout -q development
   commit_msg "feat: 7"
   commit_msg "feat: 8"
-  assert_calc "S21" "development" "[0-9]+\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S21" "development" "" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.1
   assert_calc "S22" "release-1.1" "1\.[0-9]+" "false" "${PRIMARY_PATTERN}" "${RELEASE_PATTERN}" "1.1.0-rc.0" "true" "false" "false" "1.1" "tag"
@@ -655,17 +655,17 @@ assert_calc() {
   init_dummy_repo "${BATS_TEST_TMPDIR}/default-version-filter"
 
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S0" "development" "" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S1" "development" "" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.1
-  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  assert_calc "S2" "release-0.1" "" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0-rc.0
 
-  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  assert_calc "S3" "release-0.1" "" "true" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0" "false" "true" "true" "0.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0
 
@@ -675,27 +675,27 @@ assert_calc() {
 
   git checkout -q -b development-1.x
   commit_msg "feat: 3"
-  assert_calc "S5" "development-1.x" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S5" "development-1.x" "" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-dev.2" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 4"
-  assert_calc "S6" "development-1.x" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-dev.3" "false" "false" "false" "" "tag"
+  assert_calc "S6" "development-1.x" "" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-dev.3" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-1.0
-  assert_calc "S7" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  assert_calc "S7" "release-1.0" "" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   git tag 1.0.0-rc.0
 
   git checkout -q development-1.x
   commit_msg "fix: 4"
   local sha_fix4="${LAST_COMMIT_SHA}"
-  assert_calc "S8" "development-1.x" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S8" "development-1.x" "" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.1.0-dev.1" "false" "false" "false" "" "tag"
 
   git checkout -q release-1.0
   cherry_pick_commit "${sha_fix4}"
-  assert_calc "S9" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  assert_calc "S9" "release-1.0" "" "false" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0-rc.1
 
-  assert_calc "S10" "release-1.0" "[0-9]+\.[0-9]+" "true" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  assert_calc "S10" "release-1.0" "" "true" "^development-1\.x$" "^release-[0-9]+\.[0-9]+$" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 }
@@ -704,17 +704,17 @@ assert_calc() {
   init_dummy_repo "${BATS_TEST_TMPDIR}/strict-version-filter"
 
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S0" "development" "" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S1" "development" "" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.1
-  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  assert_calc "S2" "release-0.1" "" "false" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0-rc.0
 
-  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  assert_calc "S3" "release-0.1" "" "true" "^development$" "^release-[0-9]+\.[0-9]+$" "0.1.0" "false" "true" "true" "0.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0
 
@@ -753,17 +753,17 @@ assert_calc() {
   init_dummy_repo "${BATS_TEST_TMPDIR}/bump-major-version-using-long-rc"
 
   commit_msg "chore: initial commit"
-  assert_calc "S0" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-dev.1" "false" "false" "false" "" "tag"
+  assert_calc "S0" "development" "" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-dev.1" "false" "false" "false" "" "tag"
 
   commit_msg "feat: 1"
-  assert_calc "S1" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-dev.2" "false" "false" "false" "" "tag"
+  assert_calc "S1" "development" "" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-dev.2" "false" "false" "false" "" "tag"
 
   git checkout -q -b release-0.1
-  assert_calc "S2" "release-0.1" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
+  assert_calc "S2" "release-0.1" "" "false" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0-rc.0" "true" "false" "false" "0.1" "tag"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0-rc.0
 
-  assert_calc "S3" "release-0.1" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0" "false" "true" "true" "0.1" "merge-base"
+  assert_calc "S3" "release-0.1" "" "true" "^development$" "^release-[0-9]\.[0-9]+" "0.1.0" "false" "true" "true" "0.1" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 0.1.0
 
@@ -774,7 +774,7 @@ assert_calc() {
 
   git checkout -q development
   git checkout -q -b release-1.0
-  assert_calc "S5" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
+  assert_calc "S5" "release-1.0" "" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0-rc.0" "true" "false" "false" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0-rc.0
 
@@ -787,18 +787,18 @@ assert_calc() {
   local sha_feat4="${LAST_COMMIT_SHA}"
   commit_msg "feat: 5"
   local sha_feat5="${LAST_COMMIT_SHA}"
-  assert_calc "S6" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.1.0-dev.4" "false" "false" "false" "" "tag"
+  assert_calc "S6" "development" "" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.1.0-dev.4" "false" "false" "false" "" "tag"
 
   git checkout -q release-1.0
   cherry_pick_commit "${sha_feat2}"
   cherry_pick_commit "${sha_feat3}"
   cherry_pick_commit "${sha_feat4}"
   cherry_pick_commit "${sha_feat5}"
-  assert_calc "S7" "release-1.0" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
+  assert_calc "S7" "release-1.0" "" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0-rc.1" "true" "false" "false" "1.0" "tag"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0-rc.1
 
-  assert_calc "S8" "release-1.0" "[0-9]+\.[0-9]+" "true" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0" "false" "true" "true" "1.0" "merge-base"
+  assert_calc "S8" "release-1.0" "" "true" "^development$" "^release-[0-9]+\.[0-9]+" "1.0.0" "false" "true" "true" "1.0" "merge-base"
   commit_msg "[skip ci] Update version"
   git tag 1.0.0
 
@@ -813,5 +813,5 @@ assert_calc() {
 
   git checkout -q development
   commit_msg "feat: 6"
-  assert_calc "S11" "development" "[0-9]+\.[0-9]+" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.1.0-dev.5" "false" "false" "false" "" "tag"
+  assert_calc "S11" "development" "" "false" "^development$" "^release-[0-9]+\.[0-9]+" "1.1.0-dev.5" "false" "false" "false" "" "tag"
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

When strict filter-version is set and no stable or RC tag matches filter then version will reset to 0.1.0.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] run tests
- [x] test on fork

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
