### PR TITLE
feat: expose ORT report-formats workflow input

### DIFF
--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -35,6 +35,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -80,6 +84,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       runs-on: ${{ inputs.runs-on }}
 
   docker_build:

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -43,6 +43,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -104,6 +108,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       runs-on: ${{ inputs.runs-on }}
 
   calculate_version:

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -35,6 +35,10 @@ on:
         type: string
         description: ORT config revision to use
         default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       runs-on:
         type: string
         description: Overrides jobs runs-on settings (json-encoded list)
@@ -68,6 +72,7 @@ jobs:
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
+          report-formats: ${{ inputs.ort-report-formats }}
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace"
           ort-config-repository: ${{ inputs.ort-config-repository }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -43,6 +43,10 @@ on:
         type: string
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
         description: ORT config revision to use
+      ort-report-formats:
+        type: string
+        default: "CycloneDx,SpdxDocument,WebApp"
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
       trivy-enabled:
         type: boolean
         default: true
@@ -98,6 +102,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       java-version: ${{ inputs.java-version }}
       java-distribution: ${{ inputs.java-distribution }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -51,6 +51,10 @@ on:
         type: string
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
         description: ORT config revision to use
+      ort-report-formats:
+        type: string
+        default: "CycloneDx,SpdxDocument,WebApp"
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
       trivy-enabled:
         type: boolean
         default: true
@@ -122,6 +126,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       java-version: ${{ inputs.java-version }}
       java-distribution: ${{ inputs.java-distribution }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -47,6 +47,10 @@ on:
         type: string
         description: ORT config revision to use
         default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+      ort-report-formats:
+        type: string
+        default: "CycloneDx,SpdxDocument,WebApp"
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
       java-version:
         type: string
         default: "17"
@@ -131,6 +135,7 @@ jobs:
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
+          report-formats: ${{ inputs.ort-report-formats }}
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Gradle"
           ort-config-repository: ${{ inputs.ort-config-repository }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -51,6 +51,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"
@@ -112,6 +116,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       node-version: ${{ inputs.node-version }}
       runs-on: ${{ inputs.runs-on }}
 

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -59,6 +59,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"
@@ -140,6 +144,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       node-version: ${{ inputs.node-version }}
       runs-on: ${{ inputs.runs-on }}
 

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -51,6 +51,10 @@ on:
         type: string
         description: ORT config revision to use
         default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       node-version:
         type: string
         description: NodeJS version to use
@@ -125,6 +129,7 @@ jobs:
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
+          report-formats: ${{ inputs.ort-report-formats }}
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=NPM"
           ort-config-repository: ${{ inputs.ort-config-repository }}

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -43,6 +43,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -98,6 +102,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       python-version: ${{ inputs.python-version }}
       poetry-version: ${{ inputs.poetry-version }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -51,6 +51,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -122,6 +126,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       python-version: ${{ inputs.python-version }}
       poetry-version: ${{ inputs.poetry-version }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -43,6 +43,10 @@ on:
         type: string
         description: ORT config revision to use
         default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       python-version:
         type: string
         description: Python version to use
@@ -160,6 +164,7 @@ jobs:
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
+          report-formats: ${{ inputs.ort-report-formats }}
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"
           ort-config-repository: ${{ inputs.ort-config-repository }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -47,6 +47,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -95,6 +99,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       trivy-enabled: ${{ inputs.trivy-enabled }}
       trivy-bypassed: ${{ inputs.trivy-bypassed }}
       trivy-severity: ${{ inputs.trivy-severity }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -55,6 +55,10 @@ on:
         type: string
         description: ORT config revision to use
         default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning
@@ -115,6 +119,7 @@ jobs:
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}
+      ort-report-formats: ${{ inputs.ort-report-formats }}
       trivy-enabled: ${{ inputs.trivy-enabled }}
       trivy-bypassed: ${{ inputs.trivy-bypassed }}
       trivy-severity: ${{ inputs.trivy-severity }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -79,6 +79,10 @@ on:
         type: string
         description: ORT config revision to use
         default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+      ort-report-formats:
+        type: string
+        description: Comma-separated list of ORT reporters to run (e.g. CycloneDx,SpdxDocument,WebApp)
+        default: "CycloneDx,SpdxDocument,WebApp"
       python-version:
         type: string
         description: Python version to use
@@ -151,6 +155,7 @@ jobs:
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
+          report-formats: ${{ inputs.ort-report-formats }}
           fail-on: "violations"
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Poetry"
           ort-config-repository: ${{ inputs.ort-config-repository }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Expose `ort-report-formats` as a workflow input across all reusable workflows that run ORT.

Consumer repositories currently cannot control which ORT reporters are generated. The default set (`CycloneDx`, `SpdxDocument`, `WebApp`) is hardcoded in `oss-review-toolkit/ort-ci-github-action` and always passed implicitly. This is a problem when the WebApp reporter fails with `OutOfMemoryError: Java heap space` on CI (ORT JVM heap is capped at 5 GiB in the action), while CycloneDX and SPDX reports are sufficient for compliance.

This change adds `ort-report-formats` to:

- `node_pr.yml`, `node_release.yml`, `node_test.yml`
- `java_pr.yml`, `java_release.yml`, `java_test.yml`
- `python_docker_pr.yml`, `python_docker_release.yml`, `python_docker_test.yml`
- `python_package_pr.yml`, `python_package_release.yml`, `python_package_test.yml`
- `generic_docker_pr.yml`, `generic_docker_release.yml`, `generic_docker_test.yml`

The input is forwarded to `ort-ci-github-action` as `report-formats`. Default value is unchanged: `CycloneDx,SpdxDocument,WebApp`.

Example for a consumer repository that needs to skip the WebApp report:

```yaml
jobs:
  run_tests:
    uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@<version>
    with:
      ort-report-formats: "CycloneDx,SpdxDocument"
    secrets: inherit
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] custom check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.