### PR TITLE
feat: use ADMIN_LOGIN/ADMIN_PASSWORD instead of users file for dial admin perf tests

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -31,7 +31,8 @@
 #     - E2E_USERNAME:                         Name(s) of application user(s) for ai-dial-chat tests
 #     - E2E_PASSWORD:                         Password for the application users
 #     - NEXT_PUBLIC_OVERLAY_USER_BUCKET:      A blob storage prefix for specific application user
-#     - DIAL_ADMIN_USERS_FILE:                Users data file for ai-dial-admin-perf tests
+#     - ADMIN_LOGIN:                           Login for ai-dial-admin-perf tests
+#     - ADMIN_PASSWORD:                        Password for ai-dial-admin-perf tests
 #     - INFLUX_HOST:                          InfluxDB host for ai-dial-admin-perf tests
 #     - INFLUX_TOKEN:                         InfluxDB token for ai-dial-admin-perf tests
 #     - AUTH0_DOMAIN:                         Auth0 domain for ai-dial-admin-perf authentication
@@ -295,7 +296,8 @@ jobs:
           E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
           NEXT_PUBLIC_OVERLAY_USER_BUCKET: ${{ secrets.NEXT_PUBLIC_OVERLAY_USER_BUCKET }}
           # ai-dial-admin-perf
-          DIAL_ADMIN_USERS_FILE: ${{ secrets.DIAL_ADMIN_USERS_FILE }}
+          ADMIN_LOGIN: ${{ secrets.ADMIN_LOGIN }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
           INFLUX_HOST: ${{ secrets.INFLUX_HOST }}
           INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}

--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,8 @@ Besides inputs, the action will have access to environment variables:
 - `E2E_PASSWORD`
 - `E2E_USERNAME`
 - `NEXT_PUBLIC_OVERLAY_USER_BUCKET`
-- `DIAL_ADMIN_USERS_FILE`
+- `ADMIN_LOGIN`
+- `ADMIN_PASSWORD`
 - `INFLUX_HOST`
 - `INFLUX_TOKEN`
 - `AUTH0_DOMAIN`


### PR DESCRIPTION
…perf tests

Replaces the DIAL_ADMIN_USERS_FILE secret with individual login/password secrets for ai-dial-admin-perf tests.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] custom check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
