### PR TITLE
fix: switch default branch for E2E tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.8.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.9.0
     needs:
       - deploy-env
     with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,6 +48,7 @@ jobs:
       e2e-host: "https://chat-${{ needs.deploy-env.outputs.github-app }}-${{ needs.deploy-env.outputs.github-sha }}.${{ vars.E2E_BASE_DOMAIN }}"
       next-public-overlay-host: "https://overlay-${{ needs.deploy-env.outputs.github-app }}-${{ needs.deploy-env.outputs.github-sha }}.${{ vars.E2E_BASE_DOMAIN }}"
       environment-name: e2e-test
+      test-branch: ${{ github.event.client_payload.test-branch || "development" }}
     secrets:
       E2E_ADMIN: ${{ secrets.E2E_ADMIN }}
       E2E_USERNAME: ${{ secrets.E2E_USERNAME }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,7 +48,6 @@ jobs:
       e2e-host: "https://chat-${{ needs.deploy-env.outputs.github-app }}-${{ needs.deploy-env.outputs.github-sha }}.${{ vars.E2E_BASE_DOMAIN }}"
       next-public-overlay-host: "https://overlay-${{ needs.deploy-env.outputs.github-app }}-${{ needs.deploy-env.outputs.github-sha }}.${{ vars.E2E_BASE_DOMAIN }}"
       environment-name: e2e-test
-      test-branch: ${{ github.event.client_payload.test-branch || "development" }}
     secrets:
       E2E_ADMIN: ${{ secrets.E2E_ADMIN }}
       E2E_USERNAME: ${{ secrets.E2E_USERNAME }}

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -114,7 +114,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.8.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -157,7 +157,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.8.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -165,7 +165,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -187,7 +187,7 @@ jobs:
         env:
           IMAGE_NAME: ${{ github.repository }}
 
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.8.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/gh-e2e-test.yml
+++ b/.github/workflows/gh-e2e-test.yml
@@ -18,7 +18,7 @@ on:
       test-branch:
         type: string
         description: E2E tests Git branch
-        default: "development"
+        default: "development-0.x"
       dotenv-file:
         type: string
         description: Path to dotenv file with E2E test variables

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -155,7 +155,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.8.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -199,7 +199,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.8.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -207,7 +207,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -215,7 +215,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.8.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -150,7 +150,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -154,7 +154,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.8.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -198,7 +198,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.8.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -206,7 +206,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -217,7 +217,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -296,7 +296,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.8.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -146,7 +146,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.8.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -189,7 +189,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.8.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -201,7 +201,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.8.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -222,7 +222,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.8.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -143,7 +143,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.8.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -160,7 +160,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.8.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -168,7 +168,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -186,7 +186,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.8.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.8.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

After development branches rename in epam/ai-dial-chat we need to switch test branch to `development-0.x`. This will fix `/deploy-review` command in component repos like core and adaptors.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
