### PR TITLE
fix: pass default e2e branch name for review command

### DIFF
--- a/.github/workflows/deploy-review-command.yml
+++ b/.github/workflows/deploy-review-command.yml
@@ -287,7 +287,7 @@ jobs:
           report-prefix: ${{ github.event.client_payload.slash_command.args.named.application }}-pr-${{ github.event.client_payload.pull_request.number }}
           # If the request dispatched from the repository with tests, pass the PR branch, otherwise we don't care
           # This is requested by QA team to verify changes in tests before rolling them out for everyone
-          test-branch: ${{ matrix.test-repository == github.event.client_payload.pull_request.head.repo.full_name && github.event.client_payload.pull_request.head.ref || '' }}
+          test-branch: ${{ matrix.test-repository == github.event.client_payload.pull_request.head.repo.full_name && github.event.client_payload.pull_request.head.ref || 'development-0.x' }}
         env:
           # ai-dial-chat
           E2E_ADMIN: ${{ secrets.E2E_ADMIN }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

This change was missed in [#584](https://github.com/epam/ai-dial-ci/pull/584). If `/deploy-review` command triggered from non-chat repository we need to pass the same default value. Otherwise it will be empty and checkout action will pull .env.ci file from default branch.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] custom check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
