### PR TITLE
feat: Update ORT

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.10.0
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -30,7 +30,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -76,7 +76,7 @@ jobs:
       style-checks-enabled: ${{ inputs.style-checks-enabled }}
       style-checks-bypassed: ${{ inputs.style-checks-bypassed }}
       ort-enabled: ${{ inputs.ort-enabled }}
-      ort-bypassed: ${{ inputs.ort-bypassed }}
+      ort-bypassed: ${{ inputs.ort-bypassed || contains(github.event.pull_request.labels.*.name, 'ort-bypassed') }}
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -26,7 +26,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -34,7 +34,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -34,7 +34,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -42,7 +42,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -38,7 +38,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -114,7 +114,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -157,7 +157,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -165,7 +165,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -187,7 +187,7 @@ jobs:
         env:
           IMAGE_NAME: ${{ github.repository }}
 
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -69,6 +69,8 @@ jobs:
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+          ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -67,7 +67,8 @@ jobs:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
-          ort-cli-args: "-P ort.forceOverwrite=true --stacktrace"
+          run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
+          # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -13,7 +13,7 @@ on:
         default: true
       style-checks-bypassed:
         type: boolean
-        description: Do not fail pipeline if style_check failed
+        description: Do not fail pipeline if style_checks failed
         default: false
       ort-enabled:
         type: boolean
@@ -58,7 +58,10 @@ jobs:
   ort:
     if: ${{ inputs.ort-enabled }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    continue-on-error: ${{ inputs.bypass-checks || inputs.ort-bypassed }}
     steps:
+      - name: Use HTTPS instead of SSH for Git cloning # recommended by ort-ci-github-action doc but not *actually* required until we'll run downloader/scanner tools
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
@@ -71,6 +74,9 @@ jobs:
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
           ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
+          ort-cli-args: >-
+            -P ort.forceOverwrite=true
+            --stacktrace
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -30,11 +30,11 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+        default: "main"
       runs-on:
         type: string
         description: Overrides jobs runs-on settings (json-encoded list)

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -62,9 +62,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
-        env:
-          CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -70,4 +70,18 @@ jobs:
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
-        continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
+      - name: Fail on ORT Analyzer errors
+        run: |
+          result="$HOME/.ort/ort-results/analyzer-result.json"
+          [ -f "$result" ] || { echo "::error::Analyzer result not found: $result"; exit 1; }
+          # Recursively collect every object with a severity+message under `analyzer`,
+          # so this works regardless of layout (top-level issues map, dependency nodes, etc.)
+          # and across all package managers (NPM, Gradle, ...).
+          filter='[.analyzer | .. | objects | select(has("severity") and has("message")) | select(.severity == "ERROR")]'
+          count=$(jq "$filter | length" "$result")
+          echo "Analyzer ERROR issues: $count"
+          if [ "$count" -gt 0 ]; then
+            jq -r "$filter[] | \"[\(.severity)] \(.source // \"unknown\"): \(.message)\"" "$result"
+            echo "::error::ORT Analyzer reported $count error(s). Check the report to address them."
+            exit 1
+          fi

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -33,7 +33,7 @@ on:
         description: Do not fail pipeline if ORT scan failed
       ort-version:
         type: string
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
         description: ORT version to use
       ort-config-repository:
         type: string
@@ -41,7 +41,7 @@ on:
         description: ORT config repository to use
       ort-config-revision:
         type: string
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
         description: ORT config revision to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -94,7 +94,7 @@ jobs:
       code-checks-enabled: ${{ inputs.code-checks-enabled }}
       code-checks-bypassed: ${{ inputs.code-checks-bypassed }}
       ort-enabled: ${{ inputs.ort-enabled }}
-      ort-bypassed: ${{ inputs.ort-bypassed }}
+      ort-bypassed: ${{ inputs.ort-bypassed || contains(github.event.pull_request.labels.*.name, 'ort-bypassed') }}
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -37,7 +37,7 @@ on:
         description: ORT version to use
       ort-config-repository:
         type: string
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
         description: ORT config repository to use
       ort-config-revision:
         type: string

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -45,7 +45,7 @@ on:
         description: ORT version to use
       ort-config-repository:
         type: string
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
         description: ORT config repository to use
       ort-config-revision:
         type: string

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -41,7 +41,7 @@ on:
         description: Do not fail pipeline if ORT scan failed
       ort-version:
         type: string
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
         description: ORT version to use
       ort-config-repository:
         type: string
@@ -49,7 +49,7 @@ on:
         description: ORT config repository to use
       ort-config-revision:
         type: string
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
         description: ORT config revision to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -155,7 +155,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -199,7 +199,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -207,7 +207,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -215,7 +215,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -132,6 +132,8 @@ jobs:
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+          ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -138,6 +138,7 @@ jobs:
             -P ort.forceOverwrite=true
             --stacktrace
             -P ort.analyzer.enabledPackageManagers=GradleInspector
+            -P ort.analyzer.packageManagers.GradleInspector.options.javaVersion=${{ inputs.java-version }}
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -130,7 +130,8 @@ jobs:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
-          ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Gradle"
+          run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
+          # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -5,40 +5,40 @@ on:
     inputs:
       bypass-checks:
         type: boolean
-        default: false
         description: Do not fail pipeline if checks failed
+        default: false
       style-checks-enabled:
         type: boolean
-        default: true
         description: Enable style_checks
+        default: true
       style-checks-bypassed:
         type: boolean
-        default: false
         description: Do not fail pipeline if style_checks failed
+        default: false
       style-task-name:
         type: string
-        default: "checkstyleMain"
         description: Gradle task name to run in style_checks
+        default: "checkstyleMain"
       code-checks-enabled:
         type: boolean
-        default: true
         description: Enable code_checks
+        default: true
       code-checks-bypassed:
         type: boolean
-        default: false
         description: Do not fail pipeline if code_checks failed
+        default: false
       ort-enabled:
         type: boolean
-        default: true
         description: Enable ORT scanning
+        default: true
       ort-bypassed:
         type: boolean
-        default: false
         description: Do not fail pipeline if ORT scan failed
+        default: false
       ort-version:
         type: string
-        default: "latest"
         description: ORT version to use
+        default: "latest"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -49,12 +49,12 @@ on:
         default: "main"
       java-version:
         type: string
-        default: "17"
         description: Java version to use
+        default: "17"
       java-distribution:
         type: string
-        default: "temurin"
         description: Java distribution to use
+        default: "temurin"
       runs-on:
         type: string
         description: Overrides jobs runs-on settings (json-encoded list)
@@ -121,7 +121,10 @@ jobs:
   ort:
     if: ${{ inputs.ort-enabled }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    continue-on-error: ${{ inputs.bypass-checks || inputs.ort-bypassed }}
     steps:
+      - name: Use HTTPS instead of SSH for Git cloning # recommended by ort-ci-github-action doc but not *actually* required until we'll run downloader/scanner tools
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -134,6 +134,10 @@ jobs:
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
           ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
+          ort-cli-args: >-
+            -P ort.forceOverwrite=true
+            --stacktrace
+            -P ort.analyzer.enabledPackageManagers=GradleInspector
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -125,9 +125,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
-        env:
-          CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -128,6 +128,9 @@ jobs:
       - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
+          docker-cli-args: >-
+            -e GPR_USERNAME=${{ github.actor }}
+            -e GPR_PASSWORD=${{ secrets.GITHUB_TOKEN }}
           allow-dynamic-versions: "true"
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -42,11 +42,11 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+        default: "main"
       java-version:
         type: string
         default: "17"

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -133,4 +133,18 @@ jobs:
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=Gradle"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
-        continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
+      - name: Fail on ORT Analyzer errors
+        run: |
+          result="$HOME/.ort/ort-results/analyzer-result.json"
+          [ -f "$result" ] || { echo "::error::Analyzer result not found: $result"; exit 1; }
+          # Recursively collect every object with a severity+message under `analyzer`,
+          # so this works regardless of layout (top-level issues map, dependency nodes, etc.)
+          # and across all package managers (NPM, Gradle, ...).
+          filter='[.analyzer | .. | objects | select(has("severity") and has("message")) | select(.severity == "ERROR")]'
+          count=$(jq "$filter | length" "$result")
+          echo "Analyzer ERROR issues: $count"
+          if [ "$count" -gt 0 ]; then
+            jq -r "$filter[] | \"[\(.severity)] \(.source // \"unknown\"): \(.message)\"" "$result"
+            echo "::error::ORT Analyzer reported $count error(s). Check the report to address them."
+            exit 1
+          fi

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -46,7 +46,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -150,7 +150,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -108,7 +108,7 @@ jobs:
       code-checks-enabled: ${{ inputs.code-checks-enabled }}
       code-checks-bypassed: ${{ inputs.code-checks-bypassed }}
       ort-enabled: ${{ inputs.ort-enabled }}
-      ort-bypassed: ${{ inputs.ort-bypassed }}
+      ort-bypassed: ${{ inputs.ort-bypassed || contains(github.event.pull_request.labels.*.name, 'ort-bypassed') }}
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -42,7 +42,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -50,7 +50,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -154,7 +154,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -198,7 +198,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -206,7 +206,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -217,7 +217,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -296,7 +296,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -54,7 +54,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -50,7 +50,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -58,7 +58,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -127,4 +127,18 @@ jobs:
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=NPM"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
-        continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
+      - name: Fail on ORT Analyzer errors
+        run: |
+          result="$HOME/.ort/ort-results/analyzer-result.json"
+          [ -f "$result" ] || { echo "::error::Analyzer result not found: $result"; exit 1; }
+          # Recursively collect every object with a severity+message under `analyzer`,
+          # so this works regardless of layout (top-level issues map, dependency nodes, etc.)
+          # and across all package managers (NPM, Gradle, ...).
+          filter='[.analyzer | .. | objects | select(has("severity") and has("message")) | select(.severity == "ERROR")]'
+          count=$(jq "$filter | length" "$result")
+          echo "Analyzer ERROR issues: $count"
+          if [ "$count" -gt 0 ]; then
+            jq -r "$filter[] | \"[\(.severity)] \(.source // \"unknown\"): \(.message)\"" "$result"
+            echo "::error::ORT Analyzer reported $count error(s). Check the report to address them."
+            exit 1
+          fi

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -124,7 +124,8 @@ jobs:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
-          ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=NPM"
+          run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
+          # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -128,6 +128,11 @@ jobs:
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
           ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
+          ort-cli-args: >-
+            -P ort.forceOverwrite=true
+            --stacktrace
+            -P ort.analyzer.enabledPackageManagers=NPM
+            -P ort.analyzer.packageManagers.NPM.options.nodeVersion=${{ inputs.node-version }}
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -126,6 +126,8 @@ jobs:
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+          ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -119,9 +119,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
-        env:
-          CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -46,11 +46,11 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+        default: "main"
       node-version:
         type: string
         description: NodeJS version to use

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -115,7 +115,10 @@ jobs:
   ort:
     if: ${{ inputs.ort-enabled }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    continue-on-error: ${{ inputs.bypass-checks || inputs.ort-bypassed }}
     steps:
+      - name: Use HTTPS instead of SSH for Git cloning # recommended by ort-ci-github-action doc but not *actually* required until we'll run downloader/scanner tools
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -34,7 +34,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -42,7 +42,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -102,7 +102,7 @@ jobs:
       code-checks-enabled: ${{ inputs.code-checks-enabled }}
       code-checks-bypassed: ${{ inputs.code-checks-bypassed }}
       ort-enabled: ${{ inputs.ort-enabled }}
-      ort-bypassed: ${{ inputs.ort-bypassed }}
+      ort-bypassed: ${{ inputs.ort-bypassed || contains(github.event.pull_request.labels.*.name, 'ort-bypassed') }}
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -38,7 +38,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -146,7 +146,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -189,7 +189,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -201,7 +201,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.9.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -222,7 +222,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -46,7 +46,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -42,7 +42,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -50,7 +50,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -185,9 +185,7 @@ jobs:
         if: ${{ inputs.python-package-manager == 'uv' }}
         run: uv export --frozen --all-extras --format requirements.txt --output-file requirements.txt
         shell: bash
-      - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
-        env:
-          CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -164,7 +164,10 @@ jobs:
   ort:
     if: ${{ inputs.ort-enabled }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    continue-on-error: ${{ inputs.bypass-checks || inputs.ort-bypassed }}
     steps:
+      - name: Use HTTPS instead of SSH for Git cloning # recommended by ort-ci-github-action doc but not *actually* required until we'll run downloader/scanner tools
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -193,4 +193,18 @@ jobs:
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
-        continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
+      - name: Fail on ORT Analyzer errors
+        run: |
+          result="$HOME/.ort/ort-results/analyzer-result.json"
+          [ -f "$result" ] || { echo "::error::Analyzer result not found: $result"; exit 1; }
+          # Recursively collect every object with a severity+message under `analyzer`,
+          # so this works regardless of layout (top-level issues map, dependency nodes, etc.)
+          # and across all package managers (NPM, Gradle, ...).
+          filter='[.analyzer | .. | objects | select(has("severity") and has("message")) | select(.severity == "ERROR")]'
+          count=$(jq "$filter | length" "$result")
+          echo "Analyzer ERROR issues: $count"
+          if [ "$count" -gt 0 ]; then
+            jq -r "$filter[] | \"[\(.severity)] \(.source // \"unknown\"): \(.message)\"" "$result"
+            echo "::error::ORT Analyzer reported $count error(s). Check the report to address them."
+            exit 1
+          fi

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -190,7 +190,8 @@ jobs:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
-          ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}"
+          run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
+          # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -194,6 +194,11 @@ jobs:
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
           ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
+          ort-cli-args: >-
+            -P ort.forceOverwrite=true
+            --stacktrace
+            -P ort.analyzer.enabledPackageManagers=${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}
+            -P ort.analyzer.packageManagers.${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}.options.pythonVersion=${{ inputs.python-version }}
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -192,6 +192,8 @@ jobs:
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+          ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -38,11 +38,11 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+        default: "main"
       python-version:
         type: string
         description: Python version to use

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -99,7 +99,7 @@ jobs:
       code-checks-bypassed: ${{ inputs.code-checks-bypassed }}
       code-checks-python-versions: ${{ inputs.code-checks-python-versions }}
       ort-enabled: ${{ inputs.ort-enabled }}
-      ort-bypassed: ${{ inputs.ort-bypassed }}
+      ort-bypassed: ${{ inputs.ort-bypassed || contains(github.event.pull_request.labels.*.name, 'ort-bypassed') }}
       ort-version: ${{ inputs.ort-version }}
       ort-config-repository: ${{ inputs.ort-config-repository }}
       ort-config-revision: ${{ inputs.ort-config-revision }}

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -38,7 +38,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -46,7 +46,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -42,7 +42,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -46,7 +46,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+        default: "92.3.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -54,7 +54,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: "5650fed55a20397b9abb9017a0c6bb674dc8481d"
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -50,7 +50,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -143,7 +143,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.9.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -160,7 +160,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.9.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -168,7 +168,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -186,7 +186,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.9.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -74,11 +74,11 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: "https://github.com/oss-review-toolkit/ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || 'main' }}
+        default: "main"
       python-version:
         type: string
         description: Python version to use

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -176,9 +176,7 @@ jobs:
         if: ${{ inputs.python-package-manager == 'uv' }}
         run: uv export --frozen --all-extras --format requirements.txt --output-file requirements.txt
         shell: bash
-      - uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.0.1
-        env:
-          CONTINUE_ON_ERROR: ${{ inputs.bypass-checks || inputs.ort-bypassed }} # Hack to use the input below as a boolean
+      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -181,7 +181,8 @@ jobs:
           image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
-          ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}"
+          run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
+          # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.9.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -185,6 +185,11 @@ jobs:
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
           ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
+          ort-cli-args: >-
+            -P ort.forceOverwrite=true
+            --stacktrace
+            -P ort.analyzer.enabledPackageManagers=${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}
+            -P ort.analyzer.packageManagers.${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}.options.pythonVersion=${{ inputs.python-version }}
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -155,7 +155,10 @@ jobs:
   ort:
     if: ${{ inputs.ort-enabled }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    continue-on-error: ${{ inputs.bypass-checks || inputs.ort-bypassed }}
     steps:
+      - name: Use HTTPS instead of SSH for Git cloning # recommended by ort-ci-github-action doc but not *actually* required until we'll run downloader/scanner tools
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -184,7 +184,21 @@ jobs:
           ort-cli-args: "-P ort.forceOverwrite=true --stacktrace -P ort.analyzer.enabledPackageManagers=${{ inputs.python-package-manager == 'uv' && 'PIP' || 'Poetry' }}"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
-        continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
+      - name: Fail on ORT Analyzer errors
+        run: |
+          result="$HOME/.ort/ort-results/analyzer-result.json"
+          [ -f "$result" ] || { echo "::error::Analyzer result not found: $result"; exit 1; }
+          # Recursively collect every object with a severity+message under `analyzer`,
+          # so this works regardless of layout (top-level issues map, dependency nodes, etc.)
+          # and across all package managers (NPM, Gradle, ...).
+          filter='[.analyzer | .. | objects | select(has("severity") and has("message")) | select(.severity == "ERROR")]'
+          count=$(jq "$filter | length" "$result")
+          echo "Analyzer ERROR issues: $count"
+          if [ "$count" -gt 0 ]; then
+            jq -r "$filter[] | \"[\(.severity)] \(.source // \"unknown\"): \(.message)\"" "$result"
+            echo "::error::ORT Analyzer reported $count error(s). Check the report to address them."
+            exit 1
+          fi
 
   trivy:
     if: ${{ inputs.trivy-enabled }}

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -183,6 +183,8 @@ jobs:
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"
           # Provide more RAM; Only applies to GitHub hosted runners for public repositories
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+          ort-jdk-java-options: "-Xmx${{ github.event.repository.private && '5' || '12' }}g"
           ort-config-repository: ${{ inputs.ort-config-repository }}
           ort-config-revision: ${{ inputs.ort-config-revision }}
       - name: Fail on ORT Analyzer errors

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@
       - [Trivy additional configuration](#trivy-additional-configuration)
       - [Dependabot](#dependabot)
         - [Dependabot Pull Requests Automation](#dependabot-pull-requests-automation)
+      - [ORT](#ort)
+        - [Control switches](#control-switches)
+        - [Configuration](#configuration)
+          - [Global config repository](#global-config-repository)
+          - [.ort.yml](#ortyml)
   - [Contributing](#contributing)
 
 ## Overview
@@ -616,7 +621,7 @@ jobs:
 ### Python (UV)
 
 > [!note]
-> UV support is enabled by setting the `python-package-manager` workflow input to `uv` (defaults to `poetry`). All workflow snippets below assume this input is set
+> UV support is enabled by setting the `python-package-manager` workflow input to `uv` (defaults to `poetry`)
 
 > [!note]
 > [ORT](https://github.com/oss-review-toolkit/ort) doesn't support analyzing UV projects directly. When `python-package-manager` is set to `uv`, the `ort` job automatically exports `uv.lock` to a `requirements.txt` file (via `uv export --frozen`) before running ORT, and analyzes it as a PIP project instead. This is transparent and requires no changes to the consumer repository, aside from having `uv.lock` committed (see [Requirements](#requirements-3) below)
@@ -1197,7 +1202,9 @@ jobs:
 
 #### Trivy additional configuration
 
-To change predefined Trivy parameters or set up additional configuration options, create `trivy.yaml` file in root of your repository. Use example below to add fallback repositories for vulnerabilities and checks DB and thus mitigate rate limit issues.
+We use [Trivy](https://trivy.dev/) for vulnerability scanning of container images and packages.
+
+To change predefined Trivy parameters or set up additional [configuration options](https://trivy.dev/docs/latest/guide/references/configuration/config-file/), create `trivy.yaml` file in root of your repository. E.g., use the configuration below to add fallback sources for Trivy databases, thus mitigate rate limit issues.
 
 `trivy.yaml`
 
@@ -1307,6 +1314,195 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
 ```
+
+#### ORT
+
+We use [OSS Review Toolkit (ORT)](https://oss-review-toolkit.org/ort/) to analyze dependencies and flag potential license compliance issues.
+
+##### Control switches
+
+Edit workflows inputs to control ORT behavior:
+
+| Input          | Default | Effect                                             |
+| -------------- | ------- | -------------------------------------------------- |
+| `ort-enabled`  | `true`  | If set to `false`, the scan will be skipped        |
+| `ort-bypassed` | `false` | If set to `true`, findings won't fail the pipeline |
+
+<details>
+  <summary>Example</summary>
+
+```yml
+jobs:
+  run_tests:
+    uses: epam/ai-dial-ci/.github/workflows/generic_docker_pr.yml@main
+    with:
+      ort-bypassed: true
+    secrets: inherit
+```
+
+</details>
+
+Alternatively, while working with PRs it's may be more convenient to set `ort-bypassed` label - same effect as `ort-bypassed: true`.
+
+> [!tip]
+> Prefer bypassing over disabling to keep visibility into compliance issues
+
+##### Configuration
+
+ORT is configured on two levels: a shared **global config repository** and a per-repository **`.ort.yml`**
+
+###### Global config repository
+
+Holds org-wide policy rules, license classifications, curations and resolutions shared across all repositories. Controlled via workflow inputs (or repository variables):
+
+| Workflow Input          | Repository variable       | Default                                                |
+| ----------------------- | ------------------------- | ------------------------------------------------------ |
+| `ort-config-repository` | `ORT_CONFIG_VCS_URL`      | `https://github.com/oss-review-toolkit/ort-config.git` |
+| `ort-config-revision`   | `ORT_CONFIG_VCS_REVISION` | Git SHA matching the pinned `ort-version`              |
+
+> [!important]
+> `ort-config-revision` must point to a SHA where `org.ossreviewtoolkit:version-catalog` version matches `ort-version` in use - the config schema evolves with ORT, so a mismatched revision can break the scan. When bumping one, bump the other too.
+
+###### .ort.yml
+
+Add an `.ort.yml` to the repository root for [project-specific configuration](https://oss-review-toolkit.org/ort/docs/configuration/ort-yml). For example:
+
+- exclude dev/test dependencies and build tooling scopes, which are not included in distributed build:
+
+  <details>
+    <summary>Node (npm)</summary>
+
+  ```yml
+  ---
+  analyzer:
+    skip_excluded: true
+  excludes:
+    paths:
+      - pattern: "package-lock.json"
+        reason: "BUILD_TOOL_OF"
+    scopes:
+      - pattern: "devDependencies"
+        reason: "DEV_DEPENDENCY_OF"
+        comment: "Packages for development only."
+  ```
+
+  </details>
+
+  <details>
+    <summary>Python (Poetry)</summary>
+
+  ```yml
+  ---
+  analyzer:
+    skip_excluded: true
+  excludes:
+    scopes:
+    - pattern: "dev"
+      reason: "DEV_DEPENDENCY_OF"
+      comment: "Packages for development only."
+    - pattern: "lint"
+      reason: "DEV_DEPENDENCY_OF"
+      comment: "Packages for static code analysis only."
+    - pattern: "test"
+      reason: "TEST_DEPENDENCY_OF"
+      comment: "Packages for testing only."
+  ```
+
+  </details>
+
+  <details>
+    <summary>Java (Gradle)</summary>
+
+  ```yml
+  ---
+  analyzer:
+    skip_excluded: true
+  excludes:
+    scopes:
+      - pattern: "annotationProcessor"
+        reason: "BUILD_DEPENDENCY_OF"
+        comment: "Packages to process code annotations only."
+      - pattern: "checkstyle"
+        reason: "DEV_DEPENDENCY_OF"
+        comment: "Packages for static code analysis only."
+      - pattern: "lombok"
+        reason: "DEV_DEPENDENCY_OF"
+        comment: "Packages from Project Lombok only."
+      - pattern: "test.*"
+        reason: "TEST_DEPENDENCY_OF"
+        comment: "Packages for testing only."
+  ```
+
+  </details>
+
+- [resolve policy rule violations](https://oss-review-toolkit.org/ort/docs/configuration/ort-yml#resolving-policy-rule-violations) that can't be fixed, matching the violation `message` with a regular expression:
+
+  <details>
+    <summary>Python (Poetry)</summary>
+
+  ```yml
+  ---
+  resolutions:
+    rule_violations:
+      # NVIDIA CUDA runtime libraries are distributed under the proprietary "NVIDIA Proprietary Software" / CUDA EULA license. There is no SPDX
+      # identifier for it that is covered by the policy rules, and it is not possible to conclude a custom LicenseRef- without it being flagged as an
+      # unhandled license. These are therefore resolved as can't-fix exceptions.
+      - message: ".*PyPI::nvidia-cu.*"
+        reason: "CANT_FIX_EXCEPTION"
+        comment: "NVIDIA Proprietary Software, see https://docs.nvidia.com/cuda/eula/index.html"
+  ```
+
+  </details>
+
+  > [!tip]
+  > Prefer adding [package curations](https://oss-review-toolkit.org/ort/docs/configuration/package-curations) over resolving violations when `NO_LICENSE_IN_DEPENDENCY` is reported
+
+- set [package-manager-specific](https://oss-review-toolkit.org/ort/docs/category/package-managers) options. Each package manager defines its own options, e.g.:
+
+  <details>
+    <summary>Node (npm)</summary>
+
+  ```yml
+  ---
+  analyzer:
+    package_managers:
+      NPM:
+        options:
+          # https://oss-review-toolkit.org/ort/docs/plugins/package-managers/NPM
+          legacyPeerDeps: false
+  ```
+
+  </details>
+
+  <details>
+    <summary>Python (Poetry)</summary>
+
+  ```yml
+  ---
+  analyzer:
+    package_managers:
+      Poetry:
+        options:
+          # https://oss-review-toolkit.org/ort/docs/plugins/package-managers/Poetry
+          operatingSystem: "linux"
+  ```
+
+  </details>
+
+  <details>
+    <summary>Java (Gradle)</summary>
+
+  ```yml
+  ---
+  analyzer:
+    package_managers:
+      Gradle:
+        options:
+          # https://oss-review-toolkit.org/ort/docs/plugins/package-managers/Gradle
+          gradleVersion: "10.3"
+  ```
+
+  </details>
 
 ## Contributing
 


### PR DESCRIPTION
### Description of changes

This is a complex upgrade and refactoring of ORT scanner usage in our workflows

1. Add more RAM when available (-Xmx12288m (12 GB) for public projects, -Xmx5120m (5 GB) for private)
1. latest version for ORT itself
1. latest version for ORT action
1. latest version for ort-config repo
1. catch Analyzer errors, e.g. when ORT can't fetch packages. Currently ORT reports green even Analyzer failed to do its job. Must respect ORT's bypass/continue on error flags
1. Add  `ort-bypassed` PR label support as alternative to workflow input
1. use Gradle Inspector instead of Gradle package manager - claimed (& proved) to be faster
1. pass proper versions to ORT (python version, java version, node version)
1. disable security scanning - we have Trivy for that
1. pass GitHub package registry credentials for java - e.g. for downloading forked jcloud in **ai-dial-core**
1. add ORT-related section to README.md
