### PR TITLE
feat: switch to forked ORT configuration repository

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
             }
 
   e2e-test:
-    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/gh-e2e-test.yml@4.11.0
     needs:
       - deploy-env
     with:

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -26,7 +26,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -34,7 +34,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/generic_docker_pr.yml
+++ b/.github/workflows/generic_docker_pr.yml
@@ -30,7 +30,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -38,7 +38,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -34,7 +34,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -42,7 +42,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/generic_docker_release.yml
+++ b/.github/workflows/generic_docker_release.yml
@@ -114,7 +114,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.11.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -157,7 +157,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.11.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -165,7 +165,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -187,7 +187,7 @@ jobs:
         env:
           IMAGE_NAME: ${{ github.repository }}
 
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.11.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -30,7 +30,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: "https://github.com/epam/ai-dial-ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/generic_docker_test.yml
+++ b/.github/workflows/generic_docker_test.yml
@@ -67,7 +67,7 @@ jobs:
           lfs: true
       - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
-          image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
+          image: "ghcr.io/oss-review-toolkit/ort-minimal:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.11.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.11.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -37,7 +37,7 @@ on:
         description: ORT version to use
       ort-config-repository:
         type: string
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
         description: ORT config repository to use
       ort-config-revision:
         type: string

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -33,7 +33,7 @@ on:
         description: Do not fail pipeline if ORT scan failed
       ort-version:
         type: string
-        default: "92.3.0"
+        default: "92.5.0"
         description: ORT version to use
       ort-config-repository:
         type: string
@@ -41,7 +41,7 @@ on:
         description: ORT config repository to use
       ort-config-revision:
         type: string
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
         description: ORT config revision to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -45,7 +45,7 @@ on:
         description: ORT version to use
       ort-config-repository:
         type: string
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
         description: ORT config repository to use
       ort-config-revision:
         type: string

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.11.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -155,7 +155,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.11.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -199,7 +199,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.11.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -207,7 +207,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.11.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -215,7 +215,7 @@ jobs:
         shell: bash
         run: |
           sed -i -E "s/^([ \t]*version[ \t]*=[ \t]*)[\"'].*[\"']/\1\"${{ needs.calculate_version.outputs.next-version }}\"/g" build.gradle
-      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.11.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -41,7 +41,7 @@ on:
         description: Do not fail pipeline if ORT scan failed
       ort-version:
         type: string
-        default: "92.3.0"
+        default: "92.5.0"
         description: ORT version to use
       ort-config-repository:
         type: string
@@ -49,7 +49,7 @@ on:
         description: ORT config repository to use
       ort-config-revision:
         type: string
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
         description: ORT config revision to use
       trivy-enabled:
         type: boolean

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -130,7 +130,7 @@ jobs:
           lfs: true
       - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
-          image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
+          image: "ghcr.io/oss-review-toolkit/ort-minimal:${{ inputs.ort-version }}"
           docker-cli-args: >-
             -e GPR_USERNAME=${{ github.actor }}
             -e GPR_PASSWORD=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.11.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/java_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/java_prepare@4.11.0
         with:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -42,7 +42,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: "https://github.com/epam/ai-dial-ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -42,7 +42,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -50,7 +50,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -46,7 +46,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/node_pr.yml
+++ b/.github/workflows/node_pr.yml
@@ -150,7 +150,7 @@ jobs:
           lfs: true
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -154,7 +154,7 @@ jobs:
       release-line: ${{ steps.semantic_versioning.outputs.release-line }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.11.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -198,7 +198,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.11.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -206,7 +206,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.11.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -217,7 +217,7 @@ jobs:
           npm version ${{ needs.calculate_version.outputs.next-version }} --no-git-tag-version --allow-same-version
       # HACK: jobs.<job_id>.if does not support hashFiles function, so we have to copy it to the each step
       - if: ${{ inputs.docker-build-enabled && (hashFiles(inputs.dockerfile-path) != '') }}
-        uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+        uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -296,7 +296,7 @@ jobs:
           IS_RELEASE: ${{ needs.calculate_version.outputs.is-release == 'true' }}
           IS_LATEST: ${{ needs.calculate_version.outputs.is-latest == 'true' }}
           RELEASE_LINE: ${{ needs.calculate_version.outputs.release-line }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.11.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -54,7 +54,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/node_release.yml
+++ b/.github/workflows/node_release.yml
@@ -50,7 +50,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -58,7 +58,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       docker-build-enabled:
         type: boolean
         description: "Enable Docker build"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -124,7 +124,7 @@ jobs:
           lfs: true
       - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
-          image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
+          image: "ghcr.io/oss-review-toolkit/ort-minimal:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -46,7 +46,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: "https://github.com/epam/ai-dial-ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/node_test.yml
+++ b/.github/workflows/node_test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.11.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.11.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/node_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/node_prepare@4.11.0
         with:
           node-version: ${{ inputs.node-version }}
           clean-install: true

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           image-names: ghcr.io/${{ env.IMAGE_NAME }}
           image-tags: test

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -38,7 +38,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_docker_pr.yml
+++ b/.github/workflows/python_docker_pr.yml
@@ -34,7 +34,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -42,7 +42,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -42,7 +42,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -50,7 +50,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -46,7 +46,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_docker_release.yml
+++ b/.github/workflows/python_docker_release.yml
@@ -146,7 +146,7 @@ jobs:
       latest-stable-tag: ${{ steps.semantic_versioning.outputs.latest-stable-tag }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.11.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -189,7 +189,7 @@ jobs:
           remove-ruby: "true"
           docker-cleanup: "true"
           set-tmpdir: "true"
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.11.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -201,7 +201,7 @@ jobs:
         shell: bash
         run: |
           sed -i "s/^version = .*/version = \"${{ needs.calculate_version.outputs.next-version-without-hyphens }}\"/g" pyproject.toml
-      - uses: epam/ai-dial-ci/actions/build_docker@4.10.0
+      - uses: epam/ai-dial-ci/actions/build_docker@4.11.0
         with:
           ghcr-username: ${{ github.actor }}
           ghcr-password: ${{ secrets.ACTIONS_BOT_TOKEN }}
@@ -222,7 +222,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
         env:
           IMAGE_NAME: ${{ github.repository }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.11.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.11.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.11.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -190,7 +190,7 @@ jobs:
         shell: bash
       - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
-          image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
+          image: "ghcr.io/oss-review-toolkit/ort-minimal:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"

--- a/.github/workflows/python_docker_test.yml
+++ b/.github/workflows/python_docker_test.yml
@@ -38,7 +38,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: "https://github.com/epam/ai-dial-ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -38,7 +38,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -46,7 +46,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -42,7 +42,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_package_pr.yml
+++ b/.github/workflows/python_package_pr.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.11.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -46,7 +46,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "92.3.0"
+        default: "92.5.0"
       ort-config-repository:
         type: string
         description: ORT config repository to use
@@ -54,7 +54,7 @@ on:
       ort-config-revision:
         type: string
         description: ORT config revision to use
-        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '53e06979539eb49f4be39db6bd605cfbe74bc98d' }} # v92.3.0
+        default: ${{ vars.ORT_CONFIG_VCS_REVISION || '92.5.0' }}
       trivy-enabled:
         type: boolean
         description: Enable Trivy scanning

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -143,7 +143,7 @@ jobs:
       is-latest: ${{ steps.semantic_versioning.outputs.is-latest }}
       changelog-mode: ${{ steps.semantic_versioning.outputs.changelog-mode }}
     steps:
-      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.10.0
+      - uses: epam/ai-dial-ci/actions/semantic_versioning@4.11.0
         id: semantic_versioning
         with:
           promote: ${{ inputs.promote }}
@@ -160,7 +160,7 @@ jobs:
       - calculate_version
       - test
     steps:
-      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.10.0
+      - uses: epam/ai-dial-ci/actions/generate_release_notes@4.11.0
         with:
           latest-tag: ${{ needs.calculate_version.outputs.latest-stable-tag }}
           use-merge-base: ${{ needs.calculate_version.outputs.changelog-mode == 'merge-base' }}
@@ -168,7 +168,7 @@ jobs:
         with:
           lfs: true
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.11.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -186,7 +186,7 @@ jobs:
           make publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.10.0
+      - uses: epam/ai-dial-ci/actions/publish_tag_release@4.11.0
         if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
         with:
           git-user-name: ${{ vars.ACTIONS_BOT_NAME || 'ai-dial-actions' }}

--- a/.github/workflows/python_package_release.yml
+++ b/.github/workflows/python_package_release.yml
@@ -50,7 +50,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/oss-review-toolkit/ort-config.git' }}
+        default: ${{ vars.ORT_CONFIG_VCS_URL || 'https://github.com/epam/ai-dial-ort-config.git' }}
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -181,7 +181,7 @@ jobs:
         shell: bash
       - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
-          image: "ghcr.io/oss-review-toolkit/ort:${{ inputs.ort-version }}"
+          image: "ghcr.io/oss-review-toolkit/ort-minimal:${{ inputs.ort-version }}"
           allow-dynamic-versions: "true"
           fail-on: "violations"
           run: "cache-dependencies, labels, analyzer, evaluator, reporter, upload-results"

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -74,7 +74,7 @@ on:
       ort-config-repository:
         type: string
         description: ORT config repository to use
-        default: "https://github.com/oss-review-toolkit/ort-config.git"
+        default: "https://github.com/epam/ai-dial-ort-config.git"
       ort-config-revision:
         type: string
         description: ORT config revision to use

--- a/.github/workflows/python_package_test.yml
+++ b/.github/workflows/python_package_test.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.11.0
         with:
           python-version: ${{ inputs.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
-      - uses: epam/ai-dial-ci/actions/python_prepare@4.10.0
+      - uses: epam/ai-dial-ci/actions/python_prepare@4.11.0
         with:
           python-version: ${{ matrix.python-version }}
           poetry-install: ${{ inputs.python-package-manager == 'poetry' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git checkout -b your-new-branch
 
 Once ready, you can create a PR back from your feature branch to a repo's default branch.
 
-We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/). Make sure to prefix the title with one of the following: `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:`. Breaking change pull requests may include `!` after the type/scope, e.g. `<type>!: <description>`.
+We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/). Make sure to prefix the title with one of the following: `fix:`, `feat:`, `docs:`, `test:`, `ci:`, `chore:`. Breaking change pull requests may include `!` after the type/scope, e.g. `<type>!: <description>`.
 
 ## Maintainers Workflow
 

--- a/README.md
+++ b/README.md
@@ -1357,21 +1357,26 @@ ORT is configured on two levels: a shared **global config repository** and a per
 
 ###### Global config repository
 
-Holds org-wide policy rules, license classifications, curations and resolutions shared across all repositories. Controlled via workflow inputs (or repository variables):
+Holds org-wide policy rules, license classifications, curations and resolutions shared across all repositories.
 
-| Workflow Input          | Repository variable       | Default                                                |
-| ----------------------- | ------------------------- | ------------------------------------------------------ |
-| `ort-config-repository` | `ORT_CONFIG_VCS_URL`      | `https://github.com/oss-review-toolkit/ort-config.git` |
-| `ort-config-revision`   | `ORT_CONFIG_VCS_REVISION` | Git SHA matching the pinned `ort-version`              |
+> [!note]
+> We've forked [the upstream](https://github.com/oss-review-toolkit/ort-config) at [epam/ai-dial-ort-config](https://github.com/epam/ai-dial-ort-config) and maintain it with our own policy rules and additional curations.
+
+ Controlled via workflow inputs (or repository variables):
+
+| Workflow Input          | Repository variable       | Default                                          |
+| ----------------------- | ------------------------- | ------------------------------------------------ |
+| `ort-config-repository` | `ORT_CONFIG_VCS_URL`      | `https://github.com/epam/ai-dial-ort-config.git` |
+| `ort-config-revision`   | `ORT_CONFIG_VCS_REVISION` | Git tag matching the pinned `ort-version`        |
 
 > [!important]
-> `ort-config-revision` must point to a SHA where `org.ossreviewtoolkit:version-catalog` version matches `ort-version` in use - the config schema evolves with ORT, so a mismatched revision can break the scan. When bumping one, bump the other too.
+> `ort-config-revision` must point to a git reference (SHA/tag/branch) where `org.ossreviewtoolkit:version-catalog` version matches `ort-version` in use - the config schema evolves with ORT, so a mismatched revision can break the scan. When bumping one, bump the other too.
 
 ###### .ort.yml
 
 Add an `.ort.yml` to the repository root for [project-specific configuration](https://oss-review-toolkit.org/ort/docs/configuration/ort-yml). For example:
 
-- exclude dev/test dependencies and build tooling scopes, which are not included in distributed build:
+- to exclude dev/test dependencies and build tooling scopes, which are not included in distributed build, thus not relevant for license compliance checks:
 
   <details>
     <summary>Node (npm)</summary>
@@ -1439,7 +1444,7 @@ Add an `.ort.yml` to the repository root for [project-specific configuration](ht
 
   </details>
 
-- [resolve policy rule violations](https://oss-review-toolkit.org/ort/docs/configuration/ort-yml#resolving-policy-rule-violations) that can't be fixed, matching the violation `message` with a regular expression:
+- to resolve [policy rule violations](https://oss-review-toolkit.org/ort/docs/configuration/ort-yml#resolving-policy-rule-violations) that can't be fixed, by matching the violation `message` with a regular expression:
 
   <details>
     <summary>Python (Poetry)</summary>
@@ -1448,20 +1453,17 @@ Add an `.ort.yml` to the repository root for [project-specific configuration](ht
   ---
   resolutions:
     rule_violations:
-      # NVIDIA CUDA runtime libraries are distributed under the proprietary "NVIDIA Proprietary Software" / CUDA EULA license. There is no SPDX
-      # identifier for it that is covered by the policy rules, and it is not possible to conclude a custom LicenseRef- without it being flagged as an
-      # unhandled license. These are therefore resolved as can't-fix exceptions.
-      - message: ".*PyPI::nvidia-cu.*"
-        reason: "CANT_FIX_EXCEPTION"
-        comment: "NVIDIA Proprietary Software, see https://docs.nvidia.com/cuda/eula/index.html"
+      - message: ".*LicenseRef-scancode-nvidia-cuda-supplement-2020.*"
+        reason: "LICENSE_ACQUIRED_EXCEPTION"
+        comment: "NVIDIA CUDA supplemental license reviewed and approved for use in this project."
   ```
 
   </details>
 
   > [!tip]
-  > Prefer adding [package curations](https://oss-review-toolkit.org/ort/docs/configuration/package-curations) over resolving violations when `NO_LICENSE_IN_DEPENDENCY` is reported
+  > Prefer adding [package curations](https://oss-review-toolkit.org/ort/docs/configuration/package-curations) over resolving violations when `NO_LICENSE_IN_DEPENDENCY` (or other fixable) findings are reported. To do that, create a new issue in [epam/ai-dial-ort-config](https://github.com/epam/ai-dial-ort-config) repository with error message(s) from the ORT scan report.
 
-- set [package-manager-specific](https://oss-review-toolkit.org/ort/docs/category/package-managers) options. Each package manager defines its own options, e.g.:
+- to set [package-manager-specific](https://oss-review-toolkit.org/ort/docs/category/package-managers) options. Each package manager defines its own options, e.g.:
 
   <details>
     <summary>Node (npm)</summary>


### PR DESCRIPTION
### Description of changes

- switch to [epam/ai-dial-ort-config](https://github.com/epam/ai-dial-ort-config/) fork to benefit from:
  - custom configuration
  - shared curations
  - semantic versioning
- switch from `ort` to `ort-minimal` container image. Twice less size (~`4.8 GB` vs ~`10.3 GB`) --> faster pull --> faster workflow run
- bump ort version to `92.5.0`

### Additional actions

When updating to this version, it's strongly recommended to:
1. Remove all **resolutions** from `.ort.yml` file
2. Get a fresh ORT scan report
3. Create new issue(s) in [ai-dial-ort-config](https://github.com/epam/ai-dial-ort-config/issues) - one issue per package is advised
4. Ensure findings were addressed (e.g. curations were created and merged into `main`)
5. Repeat ORT scan, verify report is clear now
6. Create **resolutions** in `.ort.yml` file for findings that can't be fixed by curations
