### PR TITLE
ci(dependabot): enable auto-merge for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -1,0 +1,23 @@
+name: Dependabot Automation
+
+on: pull_request_target
+
+permissions: {}
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository_owner == 'epam'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+      - name: Enable auto-merge for Dependabot PRs
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1303,7 +1303,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"
         env:


### PR DESCRIPTION
### Description of changes

Enable auto-merge for Dependabot PRs. The PR will still be blocked by approval gate, this just cuts out additional action (merge button hit) maintainer must perform.
For additional safety, only `minor` and `patch` versions can be auto-merged.